### PR TITLE
Update instructions to work on a fairly empty R installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,14 @@ you'll lose all your variables if it crashes.
 
 ##Installing
 
-You'll need zmq development headers to compile rzmq. Install this, e.g. with apt:
+You'll need zmq development headers to compile rzmq, as well as a few other dev
+and R libraries. On a recent Ubuntu/Debian installation, you can get these
+with:
 
 ```Shell
 sudo apt-get install libzmq3-dev
+sudo apt-get install libcurl4-openssl-dev 
+sudo apt-get install r-cran-reshape2 r-cran-rcpp
 ```
 
 or with homebrew:
@@ -22,10 +26,16 @@ brew upgrade zmq
 ```
 
 We need development versions of several packages from Github for now, due to
-recent fixes:
+recent fixes. First, you need to make sure you have both the `devtools` and
+`knitr` R packages available. If you don't, at the R console type:
 
 ```coffee
-# If you don't already have devtools, install.packages("devtools")
+install.packages(c("devtools", "knitr"))
+```
+
+Then, you can install the necessary development dependencies with:
+
+```coffee
 library(devtools)
 install_github("armstrtw/rzmq")
 install_github("hadley/evaluate")
@@ -35,9 +45,9 @@ install_github("takluyver/IRkernel")
 ```
 
 You'll also need [IPython](http://ipython.org/). If you already have a Python
-environment set up, install IPython using your preferred tools. If not, installing
-[Anaconda](http://continuum.io/downloads) is the quickest way to get everything
-you need.
+environment set up, install IPython using your preferred tools. If not,
+installing [Anaconda](http://continuum.io/downloads) is the quickest way to get
+everything you need.
 
 # Running the notebook
 


### PR DESCRIPTION
A few package dependencies were missing from the instructions. This
has now been tested on an install that has very few R packages.
