### PR TITLE
correct socket types

### DIFF
--- a/R/kernel.r
+++ b/R/kernel.r
@@ -139,9 +139,9 @@ initialize = function(connection_file) {
     sockets <<- list(
         hb = init.socket(zmqctx, "ZMQ_REP"),
         iopub = init.socket(zmqctx, "ZMQ_PUB"),
-        control = init.socket(zmqctx, "ZMQ_DEALER"),
-        stdin = init.socket(zmqctx, "ZMQ_DEALER"),
-        shell = init.socket(zmqctx, "ZMQ_DEALER")
+        control = init.socket(zmqctx, "ZMQ_ROUTER"),
+        stdin = init.socket(zmqctx, "ZMQ_ROUTER"),
+        shell = init.socket(zmqctx, "ZMQ_ROUTER")
     )
     bind.socket(sockets$hb, url_with_port("hb_port"))
     bind.socket(sockets$iopub, url_with_port("iopub_port"))


### PR DESCRIPTION
kernel sockets should be ROUTER, not DEALER.

DEALER won't fail as long as only one fronted is connected, but will round-robin replies across clients if there is more than one.
