### PR TITLE
Propose installing RCurl as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ install.packages("devtools")
 Then, you can install the necessary development dependencies with:
 
 ```coffee
+# Need RCurl for install_github
+install.packages('RCurl')
 library(devtools)
 install_github('armstrtw/rzmq', pull=8, ref=NULL)
 install_github("takluyver/IRdisplay")


### PR DESCRIPTION
When using `install_github` I ran into an error which helpfully led me to [this stackoverflow question](http://stackoverflow.com/questions/23287685/devtoolsinstall-github-error-in-function-type-msg-aserror-true-not-se).
