### PR TITLE
Set topLevelEnvironment option when running user code

### DIFF
--- a/R/execution.r
+++ b/R/execution.r
@@ -10,6 +10,15 @@ namedlist <- function() {
     return(setNames(list(), character(0)))
 }
 
+# This function copied from testthat, by Hadley Wickham. MIT licensed.
+# https://github.com/cran/testthat/blob/9e78f643d5b1c5d5882849508772ecbe980d3ac9/R/test-package.r
+with_top_env <- function(env, code) {
+    old <- options(topLevelEnvironment = env)
+    on.exit(options(old), add = TRUE)
+
+    code
+}
+
 Executor = setRefClass("Executor",
             fields=c("execution_count", "userenv", "payload", "err", "interrupted", "kernel"),
             methods = list(
@@ -93,12 +102,14 @@ execute = function(request) {
                           )
 
   interrupted <<- FALSE
-  tryCatch(
-    evaluate(request$content$code, envir=userenv, output_handler=oh,
-                stop_on_error=0),
-        interrupt = function(cond) {interrupted <<- TRUE},
-        error = handle_error  # evaluate does not catch errors in parsing
-    )
+  with_top_env(userenv, {
+      tryCatch(
+        evaluate(request$content$code, envir=userenv, output_handler=oh,
+                    stop_on_error=0),
+            interrupt = function(cond) {interrupted <<- TRUE},
+            error = handle_error  # evaluate does not catch errors in parsing
+        )
+  })
   
   send_response("status", request, 'iopub', list(execution_state="idle"))
   


### PR DESCRIPTION
Function copied from testthat

Fixes gh-33 (hopefully)
