### PR TITLE
Fix for paths containing spaces on Windows

### DIFF
--- a/R/kernel.r
+++ b/R/kernel.r
@@ -244,7 +244,8 @@ main <- function(connection_file="") {
 #'@export
 installspec <- function(user=T) {
     srcdir = system.file("kernelspec", package="IRkernel")
+    srcdir = paste("\"",srcdir,"\"",sep="")
     user_flag=ifelse(user, "--user", "")
-    cmd = paste("ipython kernelspec install --replace --name ir", user_flag, srcdir, sep=" ")
+    cmd = paste("ipython kernelspec install --replace --name ir", user_flag,srcdir, sep=" ")
     system(cmd, wait=TRUE)
 }


### PR DESCRIPTION
This fixes issue #75 
I haven't been able to check that I haven't broken anything on Mac or Linux yet but I suspect that the quotes won't affect anything there.