### PR TITLE
Update Readme with new information how to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,53 @@ This is still experimental. Your code should be safe,
 since IPython handles saving and loading notebooks in another process, but
 you'll lose all your variables if it crashes.
 
-## Installing
+## Requirements
+
+To run IPython with an R kernel, you need at least the following:
+
+* [IPython](http://ipython.org/), version 3.0 or later. If you already have a 
+  Python environment set up, install IPython using your preferred tools. If 
+  not, installing [Anaconda](http://continuum.io/downloads) is the quickest 
+  way to get everything you need. Earlier versions of IPython are now 
+  unsupported.
+* A current [R installation](http://www.r-project.org/).
+
+Installing from source needs additionally header files (see below).
+
+## Installing via supplied binary packages (Windows)
+
+We provide windows binary packages of all the needed packages. The packages 
+and the kernel spec can be installed with the following lines in an R console: 
+
+```r
+install.packages(c("rzmq","repr","IRkernel","IRdisplay"), repos="http://irkernel.github.io/")
+IRkernel::installspec()
+```
+
+To update packages, you have to either add the repo to your default ones in your R startup 
+file and update afterwards as normal:
+
+```r
+r <- getOption("repos")
+r["IRkernel"] <- "http://irkernel.github.io/"
+options(repos = r)
+```
+
+Or use the `repo` option to `update.packages()` directly:
+
+```r
+update.packages(repos="http://irkernel.github.io/")
+```
+
+Please note that during the initial development, these packages can be updated
+without changing the version number, which prevents updating via `update.packages()`. 
+In that case, updated packages can be installed by re-running the above 
+`install.packages()` line.
+
+## Installing from source (Linux/Mac)
 
 1. You'll need zmq development headers to compile rzmq, as well curl headers
    for R devtools.
-
   * **Ubuntu/Debian**
 
     ```bash
@@ -25,59 +67,61 @@ you'll lose all your variables if it crashes.
     ```
 
   * **MacPorts**
-
     * make sure an [X server is installed](http://xquartz.macosforge.org/),
       open a terminal and do the following:
 
-        ```bash
-        sudo port install zmq
-        ```
+      ```bash
+      sudo port install zmq
+      ```
 
     * Direct the compiler to use MacPorts libraries using:
 
-        ```bash
-        export CPATH=/opt/local/include
-        export LIBRARY_PATH=/opt/local/lib
-        ```
+      ```bash
+      export CPATH=/opt/local/include
+      export LIBRARY_PATH=/opt/local/lib
+      ```
+  * **Windows**
+    See [this bugreport](https://github.com/IRkernel/IRkernel/issues/54#issuecomment-84467798)
+    for instruction on how to compile on windows.
 
 2. Start `R` in the same terminal, and proceed as below:
 
-  * We need development versions of several packages from Github for now,
-    due to recent fixes. First, you need to make sure you have the `devtools`
-    R package available. If you don't, at the R console type:
+  You can install snapshot packages and the kernel spec via
 
-    ```coffee
-    install.packages("devtools")
-    ```
+  ```r
+  install.packages(c("rzmq","repr","IRkernel","IRdisplay"), repos="http://irkernel.github.io/", type="source")
+  IRkernel::installspec()
+  ```
 
-  * Then, you can install the necessary development dependencies with:
+  If you want to compile the latest and greatest (and maybe buggiest...) from git, 
+  the easiest way is via the `devtools` package:
 
-    ```coffee
-    # Need RCurl for install_github
-    install.packages('RCurl')
-    library(devtools)
-    install_github('armstrtw/rzmq')
-    install_github('IRkernel/repr')
-    install_github('IRkernel/IRdisplay')
-    install_github('IRkernel/IRkernel')
+  ```r
+  install.packages("devtools")
+  # Need RCurl for install_github
+  install.packages('RCurl')
+  library(devtools)
+  # Install the packages
+  install_github('armstrtw/rzmq')
+  install_github('IRkernel/repr')
+  install_github('IRkernel/IRdisplay')
+  install_github('IRkernel/IRkernel')
+  # Install the kernel spec
+  IRkernel::installspec()
+  ```
 
-    # Only if you have IPython 3 or above installed:
-    IRkernel::installspec()
-    ```
+Updating packages can be done via re-running the installation steps.
+   
+## Running the notebook
 
-3. You'll also need [IPython](http://ipython.org/). If you already have a
-   Python environment set up, install IPython using your preferred tools. If
-   not, installing [Anaconda](http://continuum.io/downloads) is the quickest
-   way to get everything you need.
+If you have IPython 3.0 installed, you can create a notebook and switch to
+IRkernel from the dropdown menu. 
 
-# Running the notebook
-
-If you have IPython 3 installed, you can create a notebook and switch to
-IRkernel from the dropdown menu. In IPython 2.x, you will need to start the
-notebook with this command:
+You can also start a 'qtconsole' with an R kernel:
 
 ```bash
-ipython notebook --KernelManager.kernel_cmd="['R', '-e', 'IRkernel::main()', '--args', '{connection_file}']"
+# "ir" is the kernel name installed by the above "IRkernel::installspec()"
+ipython qtconsole --kernel=ir
 ```
 
-You can also substitute 'qtconsole' or 'console' for 'notebook' in this command.
+You can also substitute 'console' for 'qtconsole' in this command.


### PR DESCRIPTION
Make installing from the supplied packages the new default and
mention that only IPython 3.1 and above is supported.

Closes: #54 # windows support