### PR TITLE
Shutdown without an error

### DIFF
--- a/R/kernel.r
+++ b/R/kernel.r
@@ -177,7 +177,7 @@ handle_control = function() {
 shutdown = function(request) {
   send_response('shutdown_reply', request, 'control',
                 list(restart=request$content$restart))
-  stop("Shut down by frontend.")
+  quit('no')
 },
 
 initialize = function(connection_file) {


### PR DESCRIPTION
This makes the error go away, but a warning is still printed to the console.

```
Warning message:
In parts[[i]] != charToRaw("<IDS|MSG>") : Lõnge des lõngeren Objektes
         ist kein Vielfaches der Lõnge des k³rzeren Objektes
```

closes #101 