### PR TITLE
Pager payload should have a data key with a mimebundle

### DIFF
--- a/R/execution.r
+++ b/R/execution.r
@@ -58,7 +58,8 @@ execute = function(request) {
         text = c(text, header, readLines(path))
     }
     if (delete.file) file.remove(files)
-    payload <<- lappend(payload, list(source='page', text=paste(text, collapse="\n")))
+    mimebundle = list(`text/plain`=paste(text, collapse="\n"))
+    payload <<- lappend(payload, list(source='page', data=mimebundle))
   })
 
   send_plot <- function(plotobj) {


### PR DESCRIPTION
I missed this when converting to msgspec 5.

Closes gh-112