### PR TITLE
Less printing on startup

### DIFF
--- a/R/kernel.r
+++ b/R/kernel.r
@@ -219,7 +219,6 @@ shutdown = function(request) {
 
 initialize = function(connection_file) {
     connection_info <<- fromJSON(connection_file)
-    print(connection_info)
     url <- paste(connection_info$transport, "://", connection_info$ip, sep = "")
     url_with_port <- function(port_name) {
         return(paste(url, ":", connection_info[port_name], sep = ""))

--- a/inst/kernelspec/kernel.json
+++ b/inst/kernelspec/kernel.json
@@ -1,3 +1,3 @@
-{"argv": ["R","-e","IRkernel::main()","--args","{connection_file}"],
+{"argv": ["R", "--quiet", "-e","IRkernel::main()","--args","{connection_file}"],
  "display_name":"R"
 }


### PR DESCRIPTION
This removes the printing of the connection info, and suppresses the default R banner.