### PR TITLE
Suggest installing the xcode client tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ You'll need zmq development headers to compile rzmq.
 *   **Homebrew**
 
     ```bash
+    xcode-select --install
     brew install zmq
     # or upgrade
     brew update
@@ -74,6 +75,7 @@ You'll need zmq development headers to compile rzmq.
         open a terminal and do the following:
 
         ```bash
+        xcode-select --install
         sudo port install zmq
         ```
 


### PR DESCRIPTION
When trying to figure out https://github.com/IRkernel/IRkernel/issues/134, even with zmq and czmq installed I was truly scratching my head.

Turns out that clang can't find those headers by default until you install the xcode command line developer tools.

```
xcode-select --install
```

Oddly, with the binary packages that are up on irkernel.github.io, I still needed to have run `xcode-select --install`...