### PR TITLE
Remove JPEG and PDF from default plot output formats

### DIFF
--- a/R/options.R
+++ b/R/options.R
@@ -20,8 +20,6 @@ opt.defaults <- list(
     jupyter.plot_mimetypes = c(
         'text/plain',
         'image/png',
-        'image/jpeg',
-        'application/pdf',
         'image/svg+xml'))
 
 .onLoad <- function(libname = NULL, pkgname = NULL) {


### PR DESCRIPTION
Leaving png, svg and text.

From discussion on #145