### PR TITLE
Only pass response function to executor

### DIFF
--- a/R/execution.r
+++ b/R/execution.r
@@ -28,17 +28,15 @@ plot_builds_upon <- function(prev, current) {
 Executor <- setRefClass(
     'Executor',
     fields = list(
+        send_response      = 'function',
         execution_count    = 'integer',
         payload            = 'list',
         err                = 'list',
         interrupted        = 'logical',
-        kernel             = 'ANY', # TODO: are reciprocal dependencies possible?
         last_recorded_plot = 'recordedplotOrNULL'),
     methods = list(
 
 execute = function(request) {
-    send_response <- kernel$send_response
-    
     send_response('status', request, 'iopub', list(
         execution_state = 'busy'))
     send_response('execute_input', request, 'iopub', list(

--- a/R/kernel.r
+++ b/R/kernel.r
@@ -267,7 +267,7 @@ initialize = function(connection_file) {
     bind.socket(sockets$stdin,   url_with_port('stdin_port'))
     bind.socket(sockets$shell,   url_with_port('shell_port'))
     
-    executor <<- Executor$new(kernel = .self)
+    executor <<- Executor$new(send_response = .self$send_response)
 },
 
 run = function() {


### PR DESCRIPTION
This way there is no two-way dependency:

The executor only knows how to send a response, not more.