### PR TITLE
installspec: use full path to R interpreter

### DIFF
--- a/R/kernel.r
+++ b/R/kernel.r
@@ -323,8 +323,19 @@ installspec <- function(user = TRUE) {
     if (!found_binary)
         stop('IPython has to be installed but could neither run ipython nor ipython2 or ipython3.')
     
+    # make a kernelspec with the current interpreter's absolute path
     srcdir <- system.file('kernelspec', package = 'IRkernel')
+    tmp_name <- tempfile()
+    dir.create(tmp_name)
+    file.copy(srcdir, tmp_name, recursive = TRUE)
+    spec_path <- file.path(tmp_name, 'kernelspec', 'kernel.json')
+    spec <- fromJSON(spec_path)
+    spec$argv[[1]] <- file.path(R.home('bin'), 'R')
+    write(toJSON(spec, pretty = TRUE), file = spec_path)
+
     user_flag <- if (user) '--user' else character(0)
-    args <- c('kernelspec', 'install', '--replace', '--name', 'ir', user_flag, srcdir)
+    args <- c('kernelspec', 'install', '--replace', '--name', 'ir', user_flag, file.path(tmp_name, 'kernelspec'))
     system2(binary, args, wait = TRUE)
+
+    unlink(tmp_name, recursive = TRUE)
 }

--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@ To run IPython with an R kernel, you need at least the following:
   way to get everything you need. Earlier versions of IPython are now 
   unsupported.
 * A current [R installation](http://www.r-project.org/).
-* You must be able to run `R` at a command prompt to start R. On Windows, you will
-  likely need to [edit the system path](http://www.computerhope.com/issues/ch000549.htm)
-  to add the directory containing `R.exe`.
 
 Installing from source needs additionally header files (see below).
 


### PR DESCRIPTION
This patch changes `installspec` to use the full path to the current R interpreter called by the process, rather than just using whatever `R` comes first on `ipython`'s `PATH`.

This makes life easier when R isn't on your path by default (as in #120 and everything mentioned by #161), or when you have multiple R installs and whatever's launching your ipython notebook server defaults to the wrong one (as in my case where I was pretty confused just now). It also matches the behavior of e.g. IJulia or `ipython kernelspec install-self`.

Not tested on Windows; someone should confirm it works there before merging.