### PR TITLE
Use display_data messages for output instead of execute_result

### DIFF
--- a/R/execution.r
+++ b/R/execution.r
@@ -189,8 +189,7 @@ execute = function(request) {
                 
                 send_response('display_data', request, 'iopub', list(
                     data = data,
-                    metadata = namedlist(),
-                ))
+                    metadata = namedlist() ))
             }
         }
         

--- a/R/execution.r
+++ b/R/execution.r
@@ -187,10 +187,10 @@ execute = function(request) {
                     }, error = handle_error)
                 }
                 
-                send_response('execute_result', request, 'iopub', list(
+                send_response('display_data', request, 'iopub', list(
                     data = data,
                     metadata = namedlist(),
-                    execution_count = execution_count))
+                ))
             }
         }
         


### PR DESCRIPTION
Closes gh-225

This would result in no `Out[n]:` prompts appearing.