### PR TITLE
Abort queued messages if an error occurs

### DIFF
--- a/R/execution.r
+++ b/R/execution.r
@@ -63,6 +63,7 @@ Executor <- setRefClass(
     'Executor',
     fields = list(
         send_response      = 'function',
+        abort_queued_messages = 'function',
         execution_count    = 'integer',
         payload            = 'list',
         err                = 'list',
@@ -258,7 +259,13 @@ execute = function(request) {
     }
     
     send_response('execute_reply', request, 'shell', reply_content)
-    
+
+    if (interrupted || !is.null(err$ename)){
+        # errors or interrupts should interrupt all currently queued messages,
+        # not only the currently running one...
+        abort_queued_messages()
+    }
+
     if (!silent) {
         execution_count <<- execution_count + 1L
     }


### PR DESCRIPTION
The notebook send all execution requests without waiting for the reply and
expects the kernel to abort requests if an error occurs (that's at least the
behavior of the python kernel).

After this commit, the R kernel aborts all shell messages (where execution
requests come in) when the kernel was either interrupted or an error occurred
during the execution of some code.

Fixes: https://github.com/IRkernel/IRkernel/issues/232