### PR TITLE
Fix hang after an aborted message

### DIFF
--- a/R/execution.r
+++ b/R/execution.r
@@ -62,13 +62,13 @@ format_stack <- function(calls) {
 Executor <- setRefClass(
     'Executor',
     fields = list(
-        send_response      = 'function',
+        send_response         = 'function',
         abort_queued_messages = 'function',
-        execution_count    = 'integer',
-        payload            = 'list',
-        err                = 'list',
-        interrupted        = 'logical',
-        last_recorded_plot = 'recordedplotOrNULL'),
+        execution_count       = 'integer',
+        payload               = 'list',
+        err                   = 'list',
+        interrupted           = 'logical',
+        last_recorded_plot    = 'recordedplotOrNULL'),
     methods = list(
 
 execute = function(request) {
@@ -260,7 +260,7 @@ execute = function(request) {
     
     send_response('execute_reply', request, 'shell', reply_content)
 
-    if (interrupted || !is.null(err$ename)){
+    if (interrupted || !is.null(err$ename)) {
         # errors or interrupts should interrupt all currently queued messages,
         # not only the currently running one...
         abort_queued_messages()


### PR DESCRIPTION
This fixes two bugs introduced by 61f0ca492e7a98c57d3c31b2020ad16642fe00e4:

* The kernel would hang in some circumstances:  It seems that zmq can't handle
  the case where the results of the first poll haven't been handled and and
  another poll is already started and the handling of the first poll is then
  resumed. In this case the main loop thought it found a control message and
  started handling it, but the function never returned from the
  `zmq.recv.multipart`. The workaround here was reordering the handle_xxx flow
  to let shell messages be handled last.

* The reply message had an incorrect type, because I forgot an unlist()

This also introduces a debug print function which does nothing and has to be activated to print to stderr...

Closes: https://github.com/IRkernel/IRkernel/issues/265