### PR TITLE
Add flag to show when we are running in a kernel

### DIFF
--- a/R/help.r
+++ b/R/help.r
@@ -8,6 +8,7 @@
 #' The following can be set/read via \code{options(opt.name = ...)} / \code{getOption('opt.name')}
 #' 
 #' \describe{
+#'   \item{\code{jupyter.in_kernel}}{\code{TRUE} if this code is executed in a running kernel}
 #'   \item{\code{jupyter.rich_display}}{Use more than just text display}
 #'   \item{\code{jupyter.result_mimetypes}}{
 #'      The formats emitted when any return value is to be displayed

--- a/R/kernel.r
+++ b/R/kernel.r
@@ -315,6 +315,7 @@ initialize = function(connection_file) {
 },
 
 run = function() {
+    options(jupyter.in_kernel = TRUE)
     while (TRUE) {
         debug('main loop: beginning')
         zmq.poll(

--- a/R/options.r
+++ b/R/options.r
@@ -20,7 +20,8 @@ opt.defaults <- list(
     jupyter.plot_mimetypes = c(
         'text/plain',
         'image/png',
-        'image/svg+xml'))
+        'image/svg+xml'),
+    jupyter.in_kernel = FALSE)
 
 .onLoad <- function(libname = NULL, pkgname = NULL) {
     for (option in names(opt.defaults)) {


### PR DESCRIPTION
We now set an options flag when we are running a kernel. This can be used to
trigger behavior changes in other packages, like using a different markdown
format when outputting markdown.

Example:

```
if (getOption("jupyter.in_kernel", FALSE)){
	# Code which should only be running when in a kernel
}
```

Closes: https://github.com/IRkernel/IRkernel/issues/24