### PR TITLE
Handle errors in display functions more gracefully

### DIFF
--- a/R/execution.r
+++ b/R/execution.r
@@ -182,15 +182,19 @@ execute = function(request) {
         # right now.
         handle_display_error <- function(e){
             # This is used with withCallingHandler and only has two additional
-            # calls at the end instead of the 3 for tryCatch...
-            calls <- head(sys.calls()[-seq_len(nframe + 1L)], -2)
+            # calls at the end instead of the 3 for tryCatch... (-2 at the end)
+            # we also remove the tryCatch and mime2repr stuff at the head of the callstack (+7)
+            calls <- head(sys.calls()[-seq_len(nframe + 7L)], -2)
             stack_info <- format_stack(calls)
             # TODO: replace with proper logging
-            cat(sprintf('ERROR: %s\nTraceback:\n%s\n', toString(e), paste(stack_info, collapse='\n')), file = stderror)
+            msg <- sprintf('ERROR while rich displaying an object: %s\nTraceback:\n%s\n',
+                           toString(e),
+                           paste(stack_info, collapse='\n'))
+            cat(msg, file = stderror)
             if (!silent) {
                 send_response('stream', request, 'iopub', list(
                     name = 'stderr',
-                    text = sprintf('Error while rich displaying an object: %s', toString(e))))
+                    text = msg))
             }
         }
         handle_value <- function(obj) {

--- a/R/execution.r
+++ b/R/execution.r
@@ -181,7 +181,9 @@ execute = function(request) {
         # is just a problem in one of the display methods which are not relevant
         # right now.
         handle_display_error <- function(e){
-            calls <- head(sys.calls()[-seq_len(nframe + 1L)], -3)
+            # This is used with withCallingHandler and only has two additional
+            # calls at the end instead of the 3 for tryCatch...
+            calls <- head(sys.calls()[-seq_len(nframe + 1L)], -2)
             stack_info <- format_stack(calls)
             # TODO: replace with proper logging
             cat(sprintf('ERROR: %s\nTraceback:\n%s\n', toString(e), paste(stack_info, collapse='\n')), file = stderror)
@@ -199,10 +201,15 @@ execute = function(request) {
             if (nchar(data[['text/plain']]) > 0) {
                 if (getOption('jupyter.rich_display')) {
                     for (mime in getOption('jupyter.display_mimetypes')) {
-                        tryCatch({
-                            r <- mime2repr[[mime]](obj)
-                            if (!is.null(r)) data[[mime]] <- r
-                            }, error = handle_display_error)
+                        # Use withCallingHandlers as that shows the inner stacktrace:
+                        # https://stackoverflow.com/questions/15282471/get-stack-trace-on-trycatched-error-in-r
+                        # the tryCatch is  still needed to prevent the error from showing
+                        # up outside further up the stack :-/
+                        tryCatch(withCallingHandlers({
+                                r <- mime2repr[[mime]](obj)
+                                if (!is.null(r)) data[[mime]] <- r
+                            }, error = handle_display_error),
+                            error=function(x){})
                     }
                 }
                 


### PR DESCRIPTION
Before, when one repr_xxx was raising an error, the complete display machinery
was impacted and no output was displayed. Now only the specific output is
omitted and a user friendly error message + stacktrace is shown on stderr and 
on the console.

Closes: https://github.com/IRkernel/IRdisplay/issues/18