### PR TITLE
Handle errors in display functions more gracefully and isolate full html pages

### DIFF
--- a/R/execution.r
+++ b/R/execution.r
@@ -174,19 +174,20 @@ execute = function(request) {
         handle_message  <- identity
         handle_warning  <- identity
     } else {
-        # We only want a short error in the notebook/... because the usual case
-        # is just a problem in one of the display methods which are not relevant
-        # right now.
         handle_display_error <- function(e){
             # This is used with withCallingHandler and only has two additional
-            # calls at the end instead of the 3 for tryCatch...
-            calls <- head(sys.calls()[-seq_len(nframe + 1L)], -2)
+            # calls at the end instead of the 3 for tryCatch... (-2 at the end)
+            # we also remove the tryCatch and mime2repr stuff at the head of the callstack (+7)
+            calls <- head(sys.calls()[-seq_len(nframe + 7L)], -2)
             stack_info <- format_stack(calls)
-            log_debug('ERROR: %s\nTraceback:\n%s\n', toString(e), paste(stack_info, collapse='\n'))
+            msg <- sprintf('ERROR while rich displaying an object: %s\nTraceback:\n%s\n',
+                           toString(e),
+                           paste(stack_info, collapse='\n'))
+            log_debug(msg)
             if (!silent) {
                 send_response('stream', request, 'iopub', list(
                     name = 'stderr',
-                    text = sprintf('Error while rich displaying an object: %s', toString(e))))
+                    text = msg))
             }
         }
         handle_value <- function(obj) {

--- a/R/execution.r
+++ b/R/execution.r
@@ -148,7 +148,7 @@ execute = function(request) {
     
     err <<- list()
     nframe <- NULL  # find out stack depth in notebook cell
-    
+
     tryCatch(evaluate(
         'stop()',
         stop_on_error = 1L,
@@ -174,6 +174,19 @@ execute = function(request) {
         handle_message  <- identity
         handle_warning  <- identity
     } else {
+        # We only want a short error in the notebook/... because the usual case
+        # is just a problem in one of the display methods which are not relevant
+        # right now.
+        handle_display_error <- function(e){
+            calls <- head(sys.calls()[-seq_len(nframe + 1L)], -3)
+            stack_info <- format_stack(calls)
+            log_debug('ERROR: %s\nTraceback:\n%s\n', toString(e), paste(stack_info, collapse='\n'))
+            if (!silent) {
+                send_response('stream', request, 'iopub', list(
+                    name = 'stderr',
+                    text = sprintf('Error while rich displaying an object: %s', toString(e))))
+            }
+        }
         handle_value <- function(obj) {
             data <- namedlist()
             data[['text/plain']] <- repr_text(obj)
@@ -181,12 +194,12 @@ execute = function(request) {
             # Only send a response when there is regular console output
             if (nchar(data[['text/plain']]) > 0) {
                 if (getOption('jupyter.rich_display')) {
-                    tryCatch({
-                        for (mime in getOption('jupyter.display_mimetypes')) {
+                    for (mime in getOption('jupyter.display_mimetypes')) {
+                        tryCatch({
                             r <- mime2repr[[mime]](obj)
                             if (!is.null(r)) data[[mime]] <- r
-                        }
-                    }, error = handle_error)
+                            }, error = handle_display_error)
+                    }
                 }
                 
                 send_response('display_data', request, 'iopub', list(

--- a/test_ir.py
+++ b/test_ir.py
@@ -26,6 +26,16 @@ class InstallspecTests(jkt.KernelTests):
 
     code_hello_world = 'print("hello, world")'
 
+class DisplaySystem(jkt.KernelTests):
+    kernel_name = 'ir'
+
+    language_name = 'R'
+
+    code_display_data = [
+    {'code': 'options(jupyter.rich_display = FALSE);cat("a")', 'mime': {'text/plain':'a'}},
+    {'code': '"a"', 'mime': {'text/plain':'"a"'}},
+    {'code': '1:3', 'mime': {'text/plain':'[1] 1 2 3'}},
+    ]
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Before, when one repr_xxx was raising an error, the complete display machinery
was impacted and no output was displayed. Now only the specific output is
omitted and a user friendly error message + stacktrace is shown on stderr and 
on the console.

Also indicate that full html pages should be isolated. Full html pages should be
isolated in the frontend in an iframe. Check if the html is a complete document
(contains html) and set the right metadata.

Closes: https://github.com/IRkernel/IRdisplay/issues/18
Closes: #284