### PR TITLE
Display htmlwidgets on print

### DIFF
--- a/R/execution.r
+++ b/R/execution.r
@@ -129,6 +129,34 @@ execute = function(request) {
     # shade base::quit
     assign('quit', quit, envir = .GlobalEnv)
     assign('q',    quit, envir = .GlobalEnv)
+
+    # This is needed to get htmlwidgets displayed on print
+    print.htmlwidget <- function(x, ...){
+
+        if (!requireNamespace("htmlwidgets", quietly = TRUE)) {
+            stop("print.htmlwidget called without htmlwidgets loaded")
+        }
+
+        htmlfile <- tempfile(fileext = ".html")
+
+        # save the widget to HTML
+        htmlwidgets::saveWidget(
+            widget = x,
+            file = htmlfile,
+            selfcontained = TRUE
+        )
+
+        html_string <- readChar(htmlfile, file.info(htmlfile)$size)
+        content <- namedlist()
+        metadata <- namedlist()
+        content[['text/html']] <- html_string
+        # self contained -> it's a complete html file which needs to go into
+        # a iframe.
+        metadata[['text/html']] <- list(isolated = TRUE)
+        publish_mimebundle(content, metadata)
+    }
+
+    assign('print.htmlwidget', print.htmlwidget, envir = .GlobalEnv)
     
     send_plot <- function(plotobj) {
         formats <- namedlist()


### PR DESCRIPTION
formattable and htmlwidgets expect to be displayed when the "thing" is printed.
For that to work, we need to add a print method which sends the html over the
wire.

We can't use a special repr_html function because `print(obj)` actually does not
print anything and our current system assumes that an empty print indicates that
the rest of the repr functions should also not be shown (which is needed for
packages like data.table which do print magic to work around some issues with
subsetting/assigning new columns not able to return invisible).

```R
df <- data.frame(
  id = 1:10,
  grade = c("C", "A", "A", "C", "B", "B", "B", "A", "C", "C"),
  stringsAsFactors = FALSE)
library(formattable)

f <- formattable(df, list(
  grade = formatter("span",
    style = x ~ ifelse(x == "A", style(color = "green", font.weight = "bold"), NA))
))
f # prints when repr_text calls print
print(f)
```