### PR TITLE
Update URL creation for the case of IPC transport.

### DIFF
--- a/R/kernel.r
+++ b/R/kernel.r
@@ -289,10 +289,12 @@ shutdown = function(request) {
 
 initialize = function(connection_file) {
     connection_info <<- fromJSON(connection_file)
+    stopifnot(connection_info$transport %in% c('tcp', 'ipc'))
     
     url <- paste0(connection_info$transport, '://', connection_info$ip)
     url_with_port <- function(port_name) {
-        paste0(url, ':', connection_info[[port_name]])
+        sep <- switch(connection_info$transport, tcp = ':', ipc = '-')
+        paste0(url, sep, connection_info[[port_name]])
     }
     
     # ZMQ Socket setup


### PR DESCRIPTION
In the case that the kernel manager <--> kernel communication happens via IPC,
there's a slight change in the way the address is formed (`-` instead of `:`
for joining the port). This shows up in the Jupyter code here:
  https://github.com/jupyter/jupyter_client/blob/cf6d354c7e81f6c61879beaf95c1f801486f758c/jupyter_client/connect.py#L442-L445

This change just makes the same tweak in IRkernel.