### PR TITLE
Save plot size in each recordedplot and use it to build images

### DIFF
--- a/R/execution.r
+++ b/R/execution.r
@@ -135,7 +135,7 @@ execute = function(request) {
         metadata <- namedlist()
         for (mime in getOption('jupyter.plot_mimetypes')) {
             tryCatch({
-                formats[[mime]] <- mime2repr[[mime]](plotobj)
+                formats[[mime]] <- mime2repr[[mime]](plotobj, attr(plotobj, '.irkernel_width'), attr(plotobj, '.irkernel_height'))
             }, error = handle_error)
             # Isolating SVGs (putting them in an iframe) avoids strange
             # interactions with CSS on the page.
@@ -221,7 +221,7 @@ execute = function(request) {
                     }
                 }
             }
-            log_debug("Sending display_data: %s", paste(capture.output(str(data)), collapse = "\n"))
+            log_debug('Sending display_data: %s', paste(capture.output(str(data)), collapse = "\n"))
             send_response('display_data', request, 'iopub', list(
                 data = data,
                 metadata = metadata))
@@ -237,6 +237,12 @@ execute = function(request) {
             if (!plot_builds_upon(last_recorded_plot, plotobj)) {
                 send_plot(last_recorded_plot)
             }
+            # need to be set here to capture the size and have it available
+            # when the plot is sent
+            # 7 is the default in repr...
+            # TODO: get default from repr when the defaults are exported there and in a release
+            attr(plotobj, '.irkernel_width') <- getOption('repr.plot.width', 7)
+            attr(plotobj, '.irkernel_height') <- getOption('repr.plot.height', 7)
             last_recorded_plot <<- plotobj
         }
         


### PR DESCRIPTION
This fixes the problem that the size of a plot would be taken from the options
when a new plot was created or when the cell was finished and not when the
original plot was created. This resulted in problems when you set the plot size
between two plots in the same cell or more specificly, you would have to set the
plot size *after* you created a plot (and before the cell was finished or a new
plot was created.

No we save the plot size at the time the plot is created and use that size to
build the images.

```
set_plot_size <- function(width = 7, height = 7){
    options(repr.plot.width = width)
    options(repr.plot.height = height)
}
set_plot_size(3,1) # ignored before, now taken for the first plot
qplot(1:10,1:10)
set_plot_size(3,3) # before for the first plot, now for the second
qplot(1:10,1:10)
set_plot_size(1,3) # before taken for the second plot, now only for following plots
```

Closes: https://github.com/IRkernel/repr/issues/42