### PR TITLE
Set default repo during the kernel session

### DIFF
--- a/R/environment.r
+++ b/R/environment.r
@@ -44,3 +44,20 @@ init_shadowenv <- function() {
         stop("'edit()' not yet supported in the Jupyter R kernel")
     })
 }
+
+init_cran_repo <- function() {
+    r <- getOption('repos')
+    is_unuseable_mirror <- identical(r, c(CRAN = '@CRAN@'))
+    if (is_unuseable_mirror) {
+        # the default repo according to https://cran.r-project.org/mirrors.html
+        # uses geo-redirects
+        r[['CRAN']] <- 'https://cran.r-project.org'
+        # attribute indicating the repos was set by us...
+        attr(r, 'irkernel') <- TRUE
+        options(repos = r)
+    }
+}
+
+init_session <- function() {
+    init_cran_repo()
+}

--- a/R/execution.r
+++ b/R/execution.r
@@ -320,7 +320,11 @@ initialize = function(...) {
     # Create the shadow env here and detach it finalize
     # so it's available for the whole lifetime of the kernel.
     attach(NULL, name = 'jupyter:irkernel')
+
+    # Add stuff to the user environment and configure a few options
+    # in the current session
     init_shadowenv()
+    init_session()
 
     callSuper(...)
 },

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -11,7 +11,7 @@ other frontends) submits to the kernel via the network.
 
 ## R CMD check results
 
-There are no WARNINGs and 1 NOTEs.
+There are no ERRORS and no WARNINGs and 1 NOTEs.
 
 Note:
 
@@ -23,7 +23,7 @@ Note:
   We use this additional environment to add functions so that regular "stuff"
   like `quit()` works in the IRkernel environment (in this case to shutdown the
   kernel). We added the "good practice" call to `detach` in `finalize` so that
-  this environment is available as long as the R kernel is running..
+  this environment is available as long as the R kernel is running.
 
 ## Downstream dependencies
 


### PR DESCRIPTION
We set repos to the default mirror of CRAN (which has geo-redirect enabled) aswe currently do not have any way to ask the user in case it is unset.
    
The setting is only set if it is unset (e.g. the user does not set it in .RProfile).

Closes: https://github.com/IRkernel/IRkernel/issues/306