### PR TITLE
added null device

### DIFF
--- a/R/environment.r
+++ b/R/environment.r
@@ -61,3 +61,13 @@ init_cran_repo <- function() {
 init_session <- function() {
     init_cran_repo()
 }
+
+
+init_null_device <- function() {
+    null_file <- switch(.Platform$OS.type, windows = 'NUL', unix = '/dev/null')
+    null_device <- function(filename = null_file, ...) png(filename, ...)
+    
+    if (identical(getOption('device'), pdf)) {
+        options(device = null_device)
+    }
+}

--- a/R/execution.r
+++ b/R/execution.r
@@ -325,6 +325,7 @@ initialize = function(...) {
     # in the current session
     init_shadowenv()
     init_session()
+    init_null_device()
 
     callSuper(...)
 },


### PR DESCRIPTION
circumvents #336 and friends

note that the device is still servicable using e.g. `dev.new('filename.png')`, as i used the null file as default argument.