### PR TITLE
Use Remotes: to install IRdisplay

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,6 @@ matrix:
 r_packages:
   - devtools
 
-r_github_packages:
-  # we currently still need IRdisplay from github in all cases...
-  - IRkernel/IRdisplay
-
 before_script:
   - source .travis.sh
   - install_r_packages

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,8 @@ Imports:
     jsonlite (>= 0.9.6),
     uuid,
     digest
+Remotes:
+  IRKernel/IRdisplay,
 Collate:
     'logging.r'
     'comm_manager.r'

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ We are currently in the process of submitting our packages to CRAN. Until then, 
 ```R
 install.packages(c('pbdZMQ', 'repr', 'devtools'))  # repr is already on CRAN
 # devtools::install_github('IRkernel/repr')        # or get the latest repr from master
-devtools::install_github('IRkernel/IRdisplay')
 devtools::install_github('IRkernel/IRkernel')
 IRkernel::installspec()  # to register the kernel in the current R installation
 ```


### PR DESCRIPTION
This uses devtools Remotes https://github.com/hadley/devtools/blob/master/vignettes/dependencies.Rmd to install the development version of IRdisplay, it should make the installation instructions a little easier.