### PR TITLE
Move rich display option

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -71,7 +71,7 @@ check_package() (
     set -ex
     
     # we don't have test_that tests yet.
-    #Rscript -e 'devtools::test(reporter="check")'
+    Rscript -e 'devtools::test(reporter="check")'
     R CMD check "$PKG_TARBALL" --as-cran
     ! grep -q 'WARNING' "$CHECK_LOG"
     # .. because ': ' was resulting in an replacement by travis and an error

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,9 @@ Authors@R: c(person("Thomas", "Kluyver", role = c("aut", "cre"), email = "thomas
     person("Karthik", "Ram", role = "aut", email = "karthik.ram@gmail.com"))
 Depends:
     R (>= 3.0.1)
+Suggests:
+	testthat,
+	roxygen2
 License: MIT + file LICENSE
 LazyData: true
 Encoding: UTF-8

--- a/R/handlers.r
+++ b/R/handlers.r
@@ -2,12 +2,17 @@ prepare_mimebundle <- function(obj, handle_display_error = log_error) {
     data <- namedlist()
     metadata <- namedlist()
     
+    # we always send text/plain, even if the user removed that from the option!
     data[['text/plain']] <- text_repr <- repr_text(obj)
     
     # Only send a response when there is regular console output
     if (!is.null(text_repr) && nchar(text_repr) > 0L) {
         if (getOption('jupyter.rich_display')) {
             for (mime in getOption('jupyter.display_mimetypes')) {
+                if (mime == 'text/plain') {
+                    # doing a print(obj) can be expensive and we don't want to do it twice!
+                    next
+                }
                 # Use withCallingHandlers as that shows the inner stacktrace:
                 # https://stackoverflow.com/questions/15282471/get-stack-trace-on-trycatched-error-in-r
                 # the tryCatch is  still needed to prevent the error from showing

--- a/R/options.r
+++ b/R/options.r
@@ -4,6 +4,7 @@
 #' @name IRkernel
 #' @export
 jupyter_option_defaults <- list(
+    jupyter.rich_display = TRUE, # moved from IRdisplay
     jupyter.log_level = 1L,
     jupyter.logfile = NA,
     jupyter.pager_classes = c(
@@ -24,7 +25,7 @@ opt_to_env <- function(nms) gsub('.', '_', toupper(nms), fixed = TRUE)
 
 .onLoad <- function(libname = NULL, pkgname = NULL) {
     for (opt_name in names(jupyter_option_defaults)) {
-        # skip option if it is set to NULL (unset)
+        # skip option if it is already set, e.g. in the Rprofile
         if (is.null(getOption(opt_name))) {
             # prepare `options` call from the default
             call_arg <- jupyter_option_defaults[opt_name]  # single [] preserve names

--- a/test_ir.py
+++ b/test_ir.py
@@ -3,10 +3,35 @@ import jupyter_kernel_test as jkt
 
 from jupyter_client.manager import start_new_kernel
 
+
+reset_rich_display = "options(jupyter.rich_display = FALSE);%s;options(jupyter.rich_display = TRUE);"
+
+
+
+class InstallspecTests(jkt.KernelTests):
+    # just a small test, it's the same kernel after all...
+    kernel_name = 'testir'
+
+    language_name = 'R'
+
+    code_hello_world = 'print("hello, world")'
+
 class IRkernelTests(jkt.KernelTests):
     kernel_name = 'ir'
 
     language_name = 'R'
+
+    def _execute_code(self, code, tests=True):
+        self.flush_channels()
+
+        reply, output_msgs = self.execute_helper(code)
+
+        self.assertEqual(reply['content']['status'], 'ok')
+        if tests:
+            self.assertGreaterEqual(len(output_msgs), 1)
+            # the irkernel only sends display_data, not execute_results
+            self.assertEqual(output_msgs[0]['msg_type'], 'display_data')
+        return reply, output_msgs
 
     code_hello_world = 'print("hello, world")'
 
@@ -18,41 +43,37 @@ class IRkernelTests(jkt.KernelTests):
     ]
 
     complete_code_samples = ['1', 'print("hello, world")', 'f <- function(x) {\n  x*2\n}']
+
     incomplete_code_samples = ['print("hello', 'f <- function(x) {\n  x*2']
 
-class InstallspecTests(jkt.KernelTests):
-    # just a small test, it's the same kernel after all...
-    kernel_name = 'testir'
+    code_display_data = [
+    {'code': '"a"', 'mime': 'text/plain'},
+    {'code': '"a"', 'mime': 'text/html'},
+    {'code': '"a"', 'mime': 'text/latex'},
+    {'code': '1:3', 'mime': 'text/plain'},
+    {'code': '1:3', 'mime': 'text/html'},
+    {'code': '1:3', 'mime': 'text/latex'},
+    {'code': (reset_rich_display%'"a"'), 'mime': 'text/plain'},
+    {'code': (reset_rich_display%'1:3'), 'mime': 'text/plain'},
+    ]
 
-    language_name = 'R'
+    def test_display_vector(self):
+        code = "1:3"
+        reply, output_msgs = self._execute_code(code)
+        # we currently send three formats: text/plain, text/html, text/latex, and text/markdown
+        self.assertEqual(len(output_msgs[0]['content']['data']), 4)
+        self.assertEqual(output_msgs[0]['content']['data']['text/plain'], "[1] 1 2 3")
+        self.assertIn('text/html', output_msgs[0]['content']['data'])
+        # this should not be a test of the repr functionality...
+        self.assertIn("</li>", output_msgs[0]['content']['data']['text/html'])
+        self.assertIn('text/latex', output_msgs[0]['content']['data'])
+        self.assertIn('text/markdown', output_msgs[0]['content']['data'])
 
-    code_hello_world = 'print("hello, world")'
-
-
-class AbstractIRKernel(jkt.KernelTests):
-    kernel_name = 'ir'
-
-    language_name = 'R'
-
-    def _execute_code(self, code):
-        self.flush_channels()
-
-        reply, output_msgs = self.execute_helper(code)
-
-        self.assertEqual(reply['content']['status'], 'ok')
-        self.assertGreaterEqual(len(output_msgs), 1)
-        # the irkernel only sends display_data, not execute_results
-        self.assertEqual(output_msgs[0]['msg_type'], 'display_data')
-        return reply, output_msgs
-
-
-class IndependendTests(AbstractIRKernel):
-
-    """This contains tests cases which do not alter the kernel environment.
-
-    They are all in one class so that unittest test case discovery does not
-    discover and skip over the default cases all the time...
-    """
+    def test_display_vector_only_plaintext(self):
+        code = reset_rich_display%"1:3"
+        reply, output_msgs = self._execute_code(code)
+        self.assertEqual(len(output_msgs[0]['content']['data']), 1)
+        self.assertEqual(output_msgs[0]['content']['data']['text/plain'], "[1] 1 2 3")
 
     def test_irkernel_plots(self):
         code = "plot(1:3)"
@@ -67,66 +88,43 @@ class IndependendTests(AbstractIRKernel):
         self.assertEqual(len(output_msgs[0]['content']['metadata']['image/svg+xml']), 1)
         self.assertEqual(output_msgs[0]['content']['metadata']['image/svg+xml']['isolated'], True)
 
-
-    def test_irkernel_default_rich_output(self):
+    def test_irkernel_plots_only_PNG(self):
+        # the reset needs to happen in another execute because plots are sent after either
+        # the next plot is opened or everything is executed, not at the time when plot
+        # command is actually happening.
+        # (we have a similar problem with width/... but we worked around it by setting the
+        # appropriate options to the recorderdplot object)
         code = """
-data.frame(x = 1:3)
+old_options <- options(jupyter.plot_mimetypes = c('image/png'))
+plot(1:3)
 """
+        reply, output_msgs = self._execute_code(code)
+        # Only png, no svg or plain/text
+        self.assertEqual(len(output_msgs[0]['content']['data']), 1)
+        self.assertIn('image/png', output_msgs[0]['content']['data'])
+        # And reset
+        code = "options(old_options)"
+        reply, output_msgs = self._execute_code(code, tests=False)
+
+    def test_irkernel_df_default_rich_output(self):
+        code = "data.frame(x = 1:3)"
         reply, output_msgs = self._execute_code(code)
         # we currently send three formats: text/plain, html, and latex
         self.assertEqual(len(output_msgs[0]['content']['data']), 3)
 
-    def test_in_kernel_set(self):
-        reply, output_msgs = self._execute_code("getOption('jupyter.in_kernel')")
-        self.assertEqual(output_msgs[0]['content']['data']['text/plain'], "[1] TRUE")
-
-
-class OptionsDependendTests(AbstractIRKernel):
-    """Test cases which need to get a new kernel because the options are changed"""
-
-    def setUp(self):
-        self.km, self.kc = start_new_kernel(kernel_name=self.kernel_name)
-
-    def tearDown(self):
-        self.kc.stop_channels()
-        self.km.shutdown_kernel()
-
-    # overwrite defaults to prevent errors on already shutdown kernels
-    @classmethod
-    def setUpClass(cls):
-        pass
-
-    @classmethod
-    def tearDownClass(cls):
-        pass
-
-
-    code_display_data = [
-    {'code': 'options(jupyter.rich_display = FALSE);cat("a")', 'mime': {'text/plain':'a'}},
-    {'code': '"a"', 'mime': {'text/plain':'"a"'}},
-    {'code': '1:3', 'mime': {'text/plain':'[1] 1 2 3'}},
-    ]
-
-    def test_irkernel_only_PNG_plots(self):
-        code = """
-options(jupyter.plot_mimetypes = 'image/png')
-plot(1:3)
-"""
-        reply, output_msgs = self._execute_code(code)
-        # Only png
-        self.assertEqual(len(output_msgs[0]['content']['data']), 1)
-        self.assertIn('image/png', output_msgs[0]['content']['data'])
-
-
-    def test_irkernel_no_rich_output(self):
+    def test_irkernel_df_no_rich_output(self):
         code = """
 options(jupyter.rich_display = FALSE)
 data.frame(x = 1:3)
+options(jupyter.rich_display = TRUE)
 """
         reply, output_msgs = self._execute_code(code)
         # only text/plain
         self.assertEqual(len(output_msgs[0]['content']['data']), 1)
 
+    def test_in_kernel_set(self):
+        reply, output_msgs = self._execute_code("getOption('jupyter.in_kernel')")
+        self.assertEqual(output_msgs[0]['content']['data']['text/plain'], "[1] TRUE")
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_ir.py
+++ b/test_ir.py
@@ -76,6 +76,10 @@ data.frame(x = 1:3)
         # we currently send three formats: text/plain, html, and latex
         self.assertEqual(len(output_msgs[0]['content']['data']), 3)
 
+    def test_in_kernel_set(self):
+        reply, output_msgs = self._execute_code("getOption('jupyter.in_kernel')")
+        self.assertEqual(output_msgs[0]['content']['data']['text/plain'], "[1] TRUE")
+
 
 class OptionsDependendTests(AbstractIRKernel):
     """Test cases which need to get a new kernel because the options are changed"""

--- a/tests/testthat.r
+++ b/tests/testthat.r
@@ -1,0 +1,4 @@
+library(testthat)
+library(IRkernel)
+
+test_check("IRkernel")

--- a/tests/testthat/test-options.r
+++ b/tests/testthat/test-options.r
@@ -1,0 +1,17 @@
+context('default options')
+
+test_that('default options are set', {
+    expect_true(getOption('jupyter.rich_display'))
+    expect_equal(getOption('jupyter.log_level'), 1L)
+    expect_equal(getOption('jupyter.logfile'), NA)
+    expect_equal(getOption('jupyter.pager_classes'), c(
+        'packageIQR',
+        'help_files_with_topic'))
+    expect_equal(getOption('jupyter.plot_mimetypes'), c(
+        'text/plain',
+        'image/png',
+        'image/svg+xml'))
+    # this is not a kernel itself, only the loaded package!
+    expect_equal(getOption('jupyter.in_kernel'), FALSE)
+})
+


### PR DESCRIPTION
IRdisplay used to set this option and now stopped using it (see https://github.com/IRkernel/IRdisplay/pull/31). Actually this option is more a "auto rich display" option, not "use rich display at all", so it fits much better in the kernel itself.
    
See https://github.com/IRkernel/IRdisplay/issues/28 for the discussion