### PR TITLE
Remove svg from the default sent image types

### DIFF
--- a/R/options.r
+++ b/R/options.r
@@ -12,8 +12,7 @@ jupyter_option_defaults <- list(
         'help_files_with_topic'),
     jupyter.plot_mimetypes = c(
         'text/plain',
-        'image/png',
-        'image/svg+xml'),
+        'image/png'),
     jupyter.in_kernel = FALSE)
 
 from_env <- list(

--- a/tests/testthat/test-options.r
+++ b/tests/testthat/test-options.r
@@ -9,8 +9,7 @@ test_that('default options are set', {
         'help_files_with_topic'))
     expect_equal(getOption('jupyter.plot_mimetypes'), c(
         'text/plain',
-        'image/png',
-        'image/svg+xml'))
+        'image/png'))
     # this is not a kernel itself, only the loaded package!
     expect_equal(getOption('jupyter.in_kernel'), FALSE)
 })


### PR DESCRIPTION
SVG currently has a few problems:

* complicated plots can lead to very big streams sent which takes ages to show up in the browser and lead to bad scrolling behaviour
* svg output in the browser is not saveable in chrome (as it is isolated into an iframe)
* using two plot formats also means that two plots have to be drawn which takes twice as long.

Closes: https://github.com/IRkernel/IRdisplay/issues/13