### PR TITLE
Adds crayon as a dependency to be installed in the docker dev image

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,6 +2,6 @@
 
 FROM jupyter/r-notebook
 
-RUN Rscript -e "install.packages(c(\"devtools\"), repos = c(\"http://irkernel.github.io/\", \"http://cran.rstudio.com\"))"
+RUN Rscript -e "install.packages(c(\"devtools\", \"crayon\"), repos = c(\"http://irkernel.github.io/\", \"http://cran.rstudio.com\"))"
 
 RUN Rscript -e "library(\"devtools\")" -e "install_github(\"IRkernel/repr\")" -e "install_github(\"IRkernel/IRdisplay\")"


### PR DESCRIPTION
Fixes https://github.com/IRkernel/IRkernel/issues/399