### PR TITLE
Dockerize running all the tests in the makefile when developing

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,6 +2,10 @@
 
 FROM jupyter/r-notebook
 
-RUN Rscript -e "install.packages(c(\"devtools\"), repos = c(\"http://irkernel.github.io/\", \"http://cran.rstudio.com\"))"
+RUN Rscript -e "install.packages(c(\"devtools\", \"testthat\", \"roxygen2\"), repos = c(\"http://irkernel.github.io/\", \"http://cran.rstudio.com\"))"
 
 RUN Rscript -e "library(\"devtools\")" -e "install_github(\"IRkernel/repr\")" -e "install_github(\"IRkernel/IRdisplay\")"
+
+RUN pip install jupyter_kernel_test ndjson-testrunner
+
+RUN unlink /opt/conda/lib/libstdc++.so.6

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: IRkernel.pdf docs check test docker_dev_image docker_dev
+.PHONY: IRkernel.pdf docs check test docker_dev_image docker_dev docker_test
 
 DEV_IMAGE:=jupyter/r-notebook-dev
 
@@ -23,3 +23,10 @@ docker_dev: docker_dev_image
 	-v `pwd`:/src_irkernel \
 	$(DEV_IMAGE) bash -c 'R CMD INSTALL -l /opt/conda/lib/R/library /src_irkernel && \
 	                        jupyter notebook --no-browser --port 8888 --ip='*''
+
+docker_test: docker_dev_image
+	@echo 'Running IRkernel tests'
+	@docker run -it --rm \
+		-v `pwd`:/src_irkernel \
+		$(DEV_IMAGE) bash -c 'R CMD build /src_irkernel && \
+		R CMD check IRkernel*.tar.gz'

--- a/README.md
+++ b/README.md
@@ -72,5 +72,6 @@ On other platforms without docker, this can be started using `docker-machine` by
 
 ```bash
 make docker_dev_image #builds dev image and installs IRkernel dependencies from github
-make docker_dev #mounts source, installs, and runs Jupyter notebook
+make docker_dev #mounts source, installs, and runs Jupyter notebook; docker_dev_image is a prerequisite
+make docker_test #builds the package from source then runs the tests via R CMD check; docker_dev_image is a prerequisite
 ```


### PR DESCRIPTION
Off the heals of #402 being fixed.
Here is the dockerized version of running the tests, which should be more convenient.