### PR TITLE
Support `inspect_request` type message.

### DIFF
--- a/R/kernel.r
+++ b/R/kernel.r
@@ -278,7 +278,7 @@ inspect = function(request) {
         tryCatch(
             {
                 # In many cases `get(token)` works, but it does not
-                # in the cases such as `token` is a numeric constants or reserved words.
+                # in the cases such as `token` is a numeric constant or reserved word.
                 # Therefore `eval()` is used here.
                 obj <- eval(parse(text = token))
 

--- a/R/kernel.r
+++ b/R/kernel.r
@@ -248,7 +248,6 @@ inspect = function(request) {
     code <- request$content$code
     cursor_pos <- request$content$cursor_pos
 
-
     section_templates <- list(
         'text/plain' = '# %1s:\n%2s\n\n',
         'text/html' = '<h1> %1s:</h1>\n%2s\n\n')
@@ -265,9 +264,9 @@ inspect = function(request) {
     # There may be better ways to do that than this.
     token <- ''
     for (i in seq(cursor_pos, nchar(code))) {
-        topic_candidate <- utils:::.guessTokenFromLine(code, i)
-        if (!grepl(token, topic_candidate)) break
-        token <- topic_candidate
+        token_candidate <- utils:::.guessTokenFromLine(code, i)
+        if (nchar(token_candidate) == 0) break
+        token <- token_candidate
     }
 
     if (nchar(token) == 0) {

--- a/R/kernel.r
+++ b/R/kernel.r
@@ -250,8 +250,8 @@ inspect = function(request) {
 
 
     section_templates <- list(
-        "text/plain" = "# %1s:\n%2s\n\n",
-        "text/html" = "<h1> %1s:</h1>\n%2s\n\n")
+        'text/plain' = '# %1s:\n%2s\n\n',
+        'text/html' = '<h1> %1s:</h1>\n%2s\n\n')
 
     add_new_section <- function (data, section_name, new_data) {
         for (mime in names(section_templates)) {
@@ -263,7 +263,7 @@ inspect = function(request) {
 
     # Get token under the cursor_pos.
     # There may be better ways to do that than this.
-    token <- ""
+    token <- ''
     for (i in seq(cursor_pos, nchar(code))) {
         topic_candidate <- utils:::.guessTokenFromLine(code, i)
         if (!grepl(token, topic_candidate)) break
@@ -279,22 +279,22 @@ inspect = function(request) {
         class_data <- tryCatch(
             IRdisplay::prepare_mimebundle(class(token)),
             error = function (e) list())
-        data <- add_new_section(data, "Class attribute", class_data)
+        data <- add_new_section(data, 'Class attribute', class_data)
 
-        code_to_get_print_mimebundle <- paste0("IRdisplay::prepare_mimebundle(", token, ")")
+        code_to_get_print_mimebundle <- paste0('IRdisplay::prepare_mimebundle(', token, ')')
         print_data <- tryCatch(
             eval(parse(text = code_to_get_print_mimebundle))$data,
             error = function (e) list())
-        data <- add_new_section(data, "Printed form", print_data)
+        data <- add_new_section(data, 'Printed form', print_data)
 
-        code_to_get_help_mimebundle <- paste0("IRdisplay::prepare_mimebundle(?", token, ")")
+        code_to_get_help_mimebundle <- paste0('IRdisplay::prepare_mimebundle(?', token, ')')
         help_data <- tryCatch({
-            help_filename <- as.character(eval(parse(text = paste0("?", token))))
+            help_filename <- as.character(eval(parse(text = paste0('?', token))))
             if (length(help_filename) > 0) {
                 help_data <- eval(parse(text = code_to_get_help_mimebundle))$data
             }},
             error = function (e) list())
-        data <- add_new_section(data, "Help document", help_data)
+        data <- add_new_section(data, 'Help document', help_data)
         found <- (length(data) != 0)
     }
     send_response('inspect_reply', request, 'shell', list(

--- a/R/kernel.r
+++ b/R/kernel.r
@@ -252,13 +252,13 @@ inspect = function(request) {
         'text/plain' = '# %s:\n',
         'text/html' = '<h1>%s:</h1>\n')
     # Function to add a section to content.
-    add_new_section <- function (data, section_name, new_data) {
-        for (mime in names(new_section_adders)) {
+    add_new_section <- function(data, section_name, new_data) {
+        for (mime in names(title_templates)) {
             new_content <- new_data[[mime]]
             if (is.null(new_content)) next
-            title <- sprintf(title_templates, section_name)
+            title <- sprintf(title_templates[[mime]], section_name)
             # use paste0 since sprintf cannot deal with format strings > 8192 bytes
-            data[[mime]] <- paste0(content, title, new_content, '\n', sep = '\n')
+            data[[mime]] <- paste0(data[[mime]], title, new_content, '\n', sep = '\n')
         }
         return(data)
     }
@@ -278,7 +278,7 @@ inspect = function(request) {
         tryCatch(
             {
                 # In many cases `get(token)` works, but it does not
-                # in the cases such as `token` is a numeric constant or reserved word.
+                # in the cases such as `token` is a numeric constant or a reserved word.
                 # Therefore `eval()` is used here.
                 obj <- eval(parse(text = token))
 
@@ -288,7 +288,7 @@ inspect = function(request) {
                 print_data <- IRdisplay::prepare_mimebundle(obj)$data
                 data <- add_new_section(data, 'Printed form', print_data)
             },
-            error = function (e) NULL)
+            error = identity)
         tryCatch(
             {
                 # `help(token)` is  not used here because it does not works
@@ -297,15 +297,14 @@ inspect = function(request) {
                 help_data <- IRdisplay::prepare_mimebundle(help_obj)$data
                 data <- add_new_section(data, 'Help document', help_data)
             },
-            error = function (e) NULL)
+            error = identity)
     }
-    found <- (length(data) != 0)
+    found <- length(data) != 0
     send_response('inspect_reply', request, 'shell', list(
         status = 'ok',
         found = found,
         data = data,
-        metadata = namedlist()
-        ))
+        metadata = namedlist()))
 },
 
 history = function(request) {

--- a/R/kernel.r
+++ b/R/kernel.r
@@ -273,25 +273,19 @@ inspect = function(request) {
         data <- list()
         found <- FALSE
     } else {
+        obj <- get(token)
         data <- list()
 
-        class_data <- tryCatch(
-            IRdisplay::prepare_mimebundle(class(token)),
-            error = function (e) list())
+        class_data <- IRdisplay::prepare_mimebundle(class(obj))$data
         data <- add_new_section(data, 'Class attribute', class_data)
 
-        code_to_get_print_mimebundle <- paste0('IRdisplay::prepare_mimebundle(', token, ')')
-        print_data <- tryCatch(
-            eval(parse(text = code_to_get_print_mimebundle))$data,
-            error = function (e) list())
+        print_data <- IRdisplay::prepare_mimebundle(obj)$data
         data <- add_new_section(data, 'Printed form', print_data)
 
         code_to_get_help_mimebundle <- paste0('IRdisplay::prepare_mimebundle(?', token, ')')
         help_data <- tryCatch({
-            help_filename <- as.character(eval(parse(text = paste0('?', token))))
-            if (length(help_filename) > 0) {
                 help_data <- eval(parse(text = code_to_get_help_mimebundle))$data
-            }},
+            },
             error = function (e) list())
         data <- add_new_section(data, 'Help document', help_data)
         found <- (length(data) != 0)

--- a/tests/testthat/test_ir.py
+++ b/tests/testthat/test_ir.py
@@ -298,6 +298,11 @@ class IRkernelTests(jkt.KernelTests):
             'f',
             preprocess='f <- function (x) x + x',
             postprocess='rm("f")')
+        # Object which masks other object in workspace
+        test_token_is_ok(
+            'c',
+            preprocess='c <- function (x) x + x',
+            postprocess='rm("c")')
 
 
 if __name__ == '__main__':

--- a/tests/testthat/test_ir.py
+++ b/tests/testthat/test_ir.py
@@ -288,17 +288,20 @@ class IRkernelTests(jkt.KernelTests):
         test_token_is_ok(
             'x',
             preprocess='x <- 1',
-            postprocess='rm("x")')
+            postprocess='rm("x")'
+        )
         # User-defined function
         test_token_is_ok(
             'f',
             preprocess='f <- function (x) x + x',
-            postprocess='rm("f")')
+            postprocess='rm("f")'
+        )
         # Object which masks other object in workspace
         test_token_is_ok(
             'c',
             preprocess='c <- function (x) x + x',
-            postprocess='rm("c")')
+            postprocess='rm("c")'
+        )
 
 
 if __name__ == '__main__':

--- a/tests/testthat/test_ir.py
+++ b/tests/testthat/test_ir.py
@@ -2,6 +2,7 @@ import unittest
 import jupyter_kernel_test as jkt
 
 from jupyter_client.manager import start_new_kernel
+from jupyter_kernel_test.messagespec import validate_message
 
 
 without_rich_display = '''\
@@ -11,6 +12,8 @@ options(jupyter.rich_display = TRUE)
 '''
 #this will not work!
 #withr::with_options(list(jupyter.rich_display = FALSE), {})
+
+TIMEOUT = 15
 
 
 class IRkernelTests(jkt.KernelTests):
@@ -238,6 +241,63 @@ class IRkernelTests(jkt.KernelTests):
         execution_count_3 = reply3['content']['execution_count']
         self.assertEqual(execution_count_1, execution_count_2)
         self.assertEqual(execution_count_1, execution_count_3)
+
+    def test_irkernel_inspects(self):
+        """Test if object inspection works."""
+        self.flush_channels()
+
+        def test_token_is_ok(token, preprocess=None, postprocess=None):
+            """Check if inspect_request for the `token` returns a reply.
+
+            Run code in `preprocess` before requesting if it's given,
+            and `proprocess` after requesting.
+
+            Currently just test if the kernel replys without an error
+            and not care about its content.
+            Because the contents of inspections are still so arguable.
+            When the requirements for the contents are decided,
+            fix the tests beow and check the contents.
+            """
+            if preprocess:
+                msg_id = self.kc.execute(preprocess, silent=True)
+                reply = self.kc.get_shell_msg(timeout=TIMEOUT)
+                validate_message(reply, 'execute_reply', msg_id)
+
+            msg_id = self.kc.inspect(token)
+            reply = self.kc.get_shell_msg(timeout=TIMEOUT)
+            validate_message(reply, 'inspect_reply', msg_id)
+
+            self.assertEqual(reply['content']['status'], 'ok')
+            self.assertTrue(reply['content']['found'])
+            self.assertGreaterEqual(len(reply['content']['data']), 1)
+
+            if postprocess:
+                msg_id = self.kc.execute(preprocess, silent=True)
+                reply = self.kc.get_shell_msg(timeout=TIMEOUT)
+                validate_message(reply, 'execute_reply', msg_id)
+
+        # Built-in constants
+        test_token_is_ok('1')
+        # Built-in constants
+        test_token_is_ok('NULL')
+        # Datasets with a help document
+        test_token_is_ok('iris')
+        # Function with a help document
+        test_token_is_ok('c')
+        # Function name with namespace
+        test_token_is_ok('base::c')
+        # Function not exported from namespace
+        test_token_is_ok('tools:::.Rd2pdf')
+        # User-defined variable
+        test_token_is_ok(
+            'x',
+            preprocess='x <- 1',
+            postprocess='rm("x")')
+        # User-defined function
+        test_token_is_ok(
+            'f',
+            preprocess='f <- function (x) x + x',
+            postprocess='rm("f")')
 
 
 if __name__ == '__main__':

--- a/tests/testthat/test_ir.py
+++ b/tests/testthat/test_ir.py
@@ -272,11 +272,11 @@ class IRkernelTests(jkt.KernelTests):
             if postprocess:
                 self._execute_code(postprocess, tests=False)
 
-        # Built-in constants
+        # Numeric constant
         test_token_is_ok('1')
-        # Built-in constants
+        # Reserved word
         test_token_is_ok('NULL')
-        # Datasets with a help document
+        # Dataset with a help document
         test_token_is_ok('iris')
         # Function with a help document
         test_token_is_ok('c')

--- a/tests/testthat/test_ir.py
+++ b/tests/testthat/test_ir.py
@@ -259,9 +259,7 @@ class IRkernelTests(jkt.KernelTests):
             fix the tests beow and check the contents.
             """
             if preprocess:
-                msg_id = self.kc.execute(preprocess, silent=True)
-                reply = self.kc.get_shell_msg(timeout=TIMEOUT)
-                validate_message(reply, 'execute_reply', msg_id)
+                self._execute_code(preprocess, tests=False)
 
             msg_id = self.kc.inspect(token)
             reply = self.kc.get_shell_msg(timeout=TIMEOUT)
@@ -272,9 +270,7 @@ class IRkernelTests(jkt.KernelTests):
             self.assertGreaterEqual(len(reply['content']['data']), 1)
 
             if postprocess:
-                msg_id = self.kc.execute(preprocess, silent=True)
-                reply = self.kc.get_shell_msg(timeout=TIMEOUT)
-                validate_message(reply, 'execute_reply', msg_id)
+                self._execute_code(postprocess, tests=False)
 
         # Built-in constants
         test_token_is_ok('1')


### PR DESCRIPTION
Dear IRkernel maintainers,

In this PR I modified IRkernel to reply `inspect_request` type message, which is currently not supported. Therefore `shift+tab` key works now, to show a tooltip or page for object inspection as below.

![tooltip](https://cloud.githubusercontent.com/assets/729653/22338256/47536036-e42a-11e6-9042-0113b5a1bacb.png)

I intended this is just a draft proposal, there will be much to improve. Especially we should discuss about the format of object inspection.

## Motivation

Though there is already well-working pager to show help page within Jupyter Notebook, there are requests to get object inspection in a tooltip as #299. Also there are and will be some apps other than Jupyter Notebook which use Jupyter messaging protocol (like JupyterLab or Hydrogen package for Atom editor) and they would use `inspect_request` message. Therefore I think supporting it is so helpful.

## Format of object inspection

Below is a brief description of the format of object inspection in my current implementation.

### Sections of object inspection

Basically an object inspection has sections as

- "Class attribute"
- "Printed form"
- "Help document".

Some sections will be omitted if we cannot extract the information.

The value of `base::class()` is used for "Class attribute" section.

The value of `IRdisplay::prepare_mimebundle()` is used for the content of "Printed form".

"Help document" uses the value of `IRdisplay::prepare_mimebundle()`, but call it with putting `?` at the head of the inspected object name.

Maybe there are several things we should add to it.

### `data` types

`data` object in `inspect_reply` message has two type, which are `text/plain` and `text/html`, for now.

`IRdisplay::prepare_mimebundle()` returns also `text/latex` type and `text/markdown` type content, so supporting them should be not so difficult.

---

You can try it with installing this branch from my repo.
```{R}
> devtools::install_github("ngr-t/IRkernel", ref = "support_inspect_request")
```

I hope this PR interests you and helps IRkernel to support good object inspection.

Thanks!