### PR TITLE
Improve the shading of readline and quit

### DIFF
--- a/R/environment_shadow.r
+++ b/R/environment_shadow.r
@@ -6,6 +6,11 @@ add_to_user_searchpath <- function(name, FN) {
     assign(name, FN, 'jupyter:irkernel')
 }
 
+add_to_base_searchpath <- function(name, FN) {
+    unlockBinding(name, baseenv())
+    assign(name, FN, baseenv())
+}
+
 get_shadowenv <- function() {
     as.environment('jupyter:irkernel')
 }
@@ -42,6 +47,9 @@ init_shadowenv <- function() {
     })
     add_to_user_searchpath('edit', function(...) {
         stop(sQuote('edit()'), ' not yet supported in the Jupyter R kernel')
+    })
+    add_to_base_searchpath('interactive', function(...) {
+        TRUE
     })
 }
 

--- a/R/environment_shadow.r
+++ b/R/environment_shadow.r
@@ -7,7 +7,7 @@ add_to_user_searchpath <- function(name, FN) {
 }
 
 replace_in_base_namespace <- function(name, FN) {
-    unlockBinding(name, baseenv())
+    .BaseNamespaceEnv$unlockBinding(name, baseenv())
     assign(name, FN, baseenv())
 }
 

--- a/R/environment_shadow.r
+++ b/R/environment_shadow.r
@@ -48,9 +48,6 @@ init_shadowenv <- function() {
     add_to_user_searchpath('edit', function(...) {
         stop(sQuote('edit()'), ' not yet supported in the Jupyter R kernel')
     })
-    add_to_base_searchpath('interactive', function(...) {
-        TRUE
-    })
 }
 
 

--- a/R/environment_shadow.r
+++ b/R/environment_shadow.r
@@ -6,7 +6,7 @@ add_to_user_searchpath <- function(name, FN) {
     assign(name, FN, 'jupyter:irkernel')
 }
 
-add_to_base_searchpath <- function(name, FN) {
+replace_in_base_namespace <- function(name, FN) {
     unlockBinding(name, baseenv())
     assign(name, FN, baseenv())
 }

--- a/R/execution.r
+++ b/R/execution.r
@@ -107,7 +107,6 @@ page = function(mimebundle) {
 
 # .Last doesn’t seem to work, so replicating behavior
 quit = function(save = 'default', status = 0, runLast = TRUE) {
-    log_debug('entering custom quit')
     save <- switch(save,
         default = , yes = TRUE,
         no = FALSE,

--- a/R/execution.r
+++ b/R/execution.r
@@ -140,6 +140,10 @@ get_pass = function(prompt = '') {
     input <- handle_stdin()
 },
 
+interactive = function() {
+    TRUE
+},
+
 handle_error = function(e) tryCatch({
     log_debug('Error output: %s', toString(e))
     calls <- head(sys.calls()[-seq_len(nframe + 1L)], -3)
@@ -243,6 +247,8 @@ execute = function(request) {
     payload <<- list()
     err <<- list()
     
+    add_to_user_searchpath('interactive', .self$interactive)
+
     # shade base::readline
     add_to_user_searchpath('readline', .self$readline)
     

--- a/R/execution.r
+++ b/R/execution.r
@@ -248,7 +248,7 @@ execute = function(request) {
     err <<- list()
     
     add_to_user_searchpath('interactive', .self$interactive)
-
+    
     # shade base::readline
     add_to_user_searchpath('readline', .self$readline)
     

--- a/R/execution.r
+++ b/R/execution.r
@@ -107,6 +107,7 @@ page = function(mimebundle) {
 
 # .Last doesn’t seem to work, so replicating behavior
 quit = function(save = 'default', status = 0, runLast = TRUE) {
+    log_debug('entering custom quit')
     save <- switch(save,
         default = , yes = TRUE,
         no = FALSE,
@@ -138,10 +139,6 @@ get_pass = function(prompt = '') {
     # wait for 'input_reply' response message
     log_debug('exiting custom get_pass')
     input <- handle_stdin()
-},
-
-interactive = function() {
-    TRUE
 },
 
 handle_error = function(e) tryCatch({
@@ -247,17 +244,15 @@ execute = function(request) {
     payload <<- list()
     err <<- list()
     
-    add_to_user_searchpath('interactive', .self$interactive)
-    
     # shade base::readline
-    add_to_user_searchpath('readline', .self$readline)
+    add_to_base_searchpath('readline', .self$readline)
     
     # shade getPass::getPass
     add_to_user_searchpath('getPass', .self$get_pass)
     
     # shade base::quit
-    add_to_user_searchpath('quit', .self$quit)
-    add_to_user_searchpath('q', .self$quit)
+    add_to_base_searchpath('quit', .self$quit)
+    add_to_base_searchpath('q', .self$quit)
 
     # find out stack depth in notebook cell
     # TODO: maybe replace with a single call on first execute and rest reuse the value?

--- a/R/execution.r
+++ b/R/execution.r
@@ -244,14 +244,14 @@ execute = function(request) {
     err <<- list()
     
     # shade base::readline
-    add_to_base_searchpath('readline', .self$readline)
+    replace_in_base_namespace('readline', .self$readline)
     
     # shade getPass::getPass
     add_to_user_searchpath('getPass', .self$get_pass)
     
     # shade base::quit
-    add_to_base_searchpath('quit', .self$quit)
-    add_to_base_searchpath('q', .self$quit)
+    replace_in_base_namespace('quit', .self$quit)
+    replace_in_base_namespace('q', .self$quit)
 
     # find out stack depth in notebook cell
     # TODO: maybe replace with a single call on first execute and rest reuse the value?


### PR DESCRIPTION
This fix better shades `readline` and `quit` to work when they are called inside other packages.