### PR TITLE
add user-specified rprofile

### DIFF
--- a/R/installspec.r
+++ b/R/installspec.r
@@ -7,6 +7,7 @@
 #' @param user         Install into user directory (\href{https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html}{\code{$XDG_DATA_HOME}}\code{/jupyter/kernels}) or globally?
 #' @param name         The name of the kernel (default "ir")
 #' @param displayname  The name which is displayed in the notebook (default: "R")
+#' @param rprofile_file Path to kernel-specific Rprofile (defaults to system-level settings)
 #' 
 #' @return Exit code of the \code{jupyter kernelspec install} call.
 #' 

--- a/R/installspec.r
+++ b/R/installspec.r
@@ -7,12 +7,12 @@
 #' @param user         Install into user directory (\href{https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html}{\code{$XDG_DATA_HOME}}\code{/jupyter/kernels}) or globally?
 #' @param name         The name of the kernel (default "ir")
 #' @param displayname  The name which is displayed in the notebook (default: "R")
-#' @param rprofile_file Path to kernel-specific Rprofile (defaults to system-level settings)
+#' @param rprofile     (optional) Path to kernel-specific Rprofile (defaults to system-level settings)
 #' 
 #' @return Exit code of the \code{jupyter kernelspec install} call.
 #' 
 #' @export
-installspec <- function(user = TRUE, name = 'ir', displayname = 'R', rprofile_file = NULL) {
+installspec <- function(user = TRUE, name = 'ir', displayname = 'R', rprofile = NULL) {
     exit_code <- system2('jupyter', c('kernelspec', '--version'), FALSE, FALSE)
     if (exit_code != 0)
         stop('jupyter-client has to be installed but ', dQuote('jupyter kernelspec --version'), ' exited with code ', exit_code, '.\n')
@@ -26,8 +26,8 @@ installspec <- function(user = TRUE, name = 'ir', displayname = 'R', rprofile_fi
     spec <- fromJSON(spec_path)
     spec$argv[[1]] <- file.path(R.home('bin'), 'R')
     spec$display_name <- displayname
-    if (!is.null(rprofile_file)) {
-        spec$env <- list(R_PROFILE_USER = rprofile_file)
+    if (!is.null(rprofile)) {
+        spec$env <- list(R_PROFILE_USER = rprofile)
     }
     write(toJSON(spec, pretty = TRUE, auto_unbox = TRUE), file = spec_path)
     

--- a/R/installspec.r
+++ b/R/installspec.r
@@ -11,7 +11,7 @@
 #' @return Exit code of the \code{jupyter kernelspec install} call.
 #' 
 #' @export
-installspec <- function(user = TRUE, name = 'ir', displayname = 'R') {
+installspec <- function(user = TRUE, name = 'ir', displayname = 'R', rprofile_file = NULL) {
     exit_code <- system2('jupyter', c('kernelspec', '--version'), FALSE, FALSE)
     if (exit_code != 0)
         stop('jupyter-client has to be installed but ', dQuote('jupyter kernelspec --version'), ' exited with code ', exit_code, '.\n')
@@ -25,6 +25,9 @@ installspec <- function(user = TRUE, name = 'ir', displayname = 'R') {
     spec <- fromJSON(spec_path)
     spec$argv[[1]] <- file.path(R.home('bin'), 'R')
     spec$display_name <- displayname
+    if (!is.null(rprofile_file)) {
+        spec$env <- list(R_PROFILE_USER = rprofile_file)
+    }
     write(toJSON(spec, pretty = TRUE, auto_unbox = TRUE), file = spec_path)
     
     user_flag <- if (user) '--user' else character(0)

--- a/man/IRkernel.Rd
+++ b/man/IRkernel.Rd
@@ -4,8 +4,10 @@
 \name{IRkernel}
 \alias{IRkernel}
 \alias{jupyter_option_defaults}
+\alias{IRkernel}
 \alias{IRkernel-package}
 \alias{IRkernel-options}
+\alias{IRkernel-package}
 \title{An R kernel for Jupyter.}
 \format{An object of class \code{list} of length 6.}
 \usage{

--- a/man/installspec.Rd
+++ b/man/installspec.Rd
@@ -4,7 +4,8 @@
 \alias{installspec}
 \title{Install the kernelspec to tell Jupyter about IRkernel.}
 \usage{
-installspec(user = TRUE, name = "ir", displayname = "R")
+installspec(user = TRUE, name = "ir", displayname = "R",
+  rprofile = NULL)
 }
 \arguments{
 \item{user}{Install into user directory (\href{https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html}{\code{$XDG_DATA_HOME}}\code{/jupyter/kernels}) or globally?}
@@ -12,6 +13,8 @@ installspec(user = TRUE, name = "ir", displayname = "R")
 \item{name}{The name of the kernel (default "ir")}
 
 \item{displayname}{The name which is displayed in the notebook (default: "R")}
+
+\item{rprofile}{(optional) Path to kernel-specific Rprofile (defaults to system-level settings)}
 }
 \value{
 Exit code of the \code{jupyter kernelspec install} call.

--- a/man/log_-times.Rd
+++ b/man/log_-times.Rd
@@ -3,7 +3,9 @@
 \name{log_*}
 \alias{log_*}
 \alias{log_debug}
+\alias{log_*}
 \alias{log_info}
+\alias{log_*}
 \alias{log_error}
 \title{Kernel logging functions}
 \usage{


### PR DESCRIPTION
Minor pull request to add an R_PROFILE_USER option to the IRkernel spec. 

In our use case, we often have project-level `.Rprofile` files & want to maintain separate kernels for each project.

