### PR TITLE
Fixed issue #460

### DIFF
--- a/R/environment_shadow.r
+++ b/R/environment_shadow.r
@@ -7,7 +7,7 @@ add_to_user_searchpath <- function(name, FN, pkg = NULL) {
         assign(name, FN, 'jupyter:irkernel')
     } else {
         env <- getNamespace(pkg)
-        unlockBinding(name, env)
+        .BaseNamespaceEnv$unlockBinding(name, env)
         assign(name, FN, envir = env, inherits = TRUE)
         lockBinding(name, env)
     }

--- a/R/environment_shadow.r
+++ b/R/environment_shadow.r
@@ -2,8 +2,15 @@
 # This is needed to build in our own needs, like properly shutting down the kernel
 # when `quit()` is called.
 
-add_to_user_searchpath <- function(name, FN) {
-    assign(name, FN, 'jupyter:irkernel')
+add_to_user_searchpath <- function(name, FN, pkg = NULL) {
+    if (is.null(pkg)) {
+        assign(name, FN, 'jupyter:irkernel')
+    } else {
+        env <- getNamespace(pkg)
+        unlockBinding(name, env)
+        assign(name, FN, envir = env, inherits = TRUE)
+        lockBinding(name, env)
+    }
 }
 
 replace_in_base_namespace <- function(name, FN) {

--- a/R/environment_shadow.r
+++ b/R/environment_shadow.r
@@ -3,14 +3,14 @@
 # when `quit()` is called.
 
 add_to_user_searchpath <- function(name, FN, pkg = NULL) {
-    if (is.null(pkg)) {
-        assign(name, FN, 'jupyter:irkernel')
-    } else {
+    tryCatch({
         env <- getNamespace(pkg)
         .BaseNamespaceEnv$unlockBinding(name, env)
         assign(name, FN, envir = env, inherits = TRUE)
-        lockBinding(name, env)
-    }
+        .BaseNamespaceEnv$lockBinding(name, env)
+    }, error = function(e) {
+        assign(name, FN, 'jupyter:irkernel')
+    })
 }
 
 replace_in_base_namespace <- function(name, FN) {

--- a/R/environment_shadow.r
+++ b/R/environment_shadow.r
@@ -3,14 +3,15 @@
 # when `quit()` is called.
 
 add_to_user_searchpath <- function(name, FN, pkg = NULL) {
-    tryCatch({
+    pkg_avail <- !is.null(pkg) && requireNamespace(pkg, quietly = TRUE)
+    if (pkg_avail) {
         env <- getNamespace(pkg)
         .BaseNamespaceEnv$unlockBinding(name, env)
         assign(name, FN, envir = env, inherits = TRUE)
         .BaseNamespaceEnv$lockBinding(name, env)
-    }, error = function(e) {
+    } else {
         assign(name, FN, 'jupyter:irkernel')
-    })
+    }
 }
 
 replace_in_base_namespace <- function(name, FN) {

--- a/R/execution.r
+++ b/R/execution.r
@@ -256,7 +256,7 @@ execute = function(request) {
     replace_in_base_namespace('readline', .self$readline)
     
     # shade getPass::getPass
-    add_to_user_searchpath('getPass', .self$get_pass)
+    add_to_user_searchpath('getPass', .self$get_pass, 'getPass')
     
     # shade base::quit
     replace_in_base_namespace('quit', .self$quit)


### PR DESCRIPTION
This fix addresses issue #460. I believe it shades the getPass package correctly and also provides an easy way to overwrite functions for other packages in the future.

As a consequence of this change, the following code will error out whereas it worked before.

```r
pass <- getPass("Enter password")
```

Since the getPass function is actually derived from a package and is not made up, notebook developers should have to explicitly attach the package. The following code will work with this fix
```r
library(getPass)
pass <- getPass("Enter password")
```

This change has the added benefit of making R notebooks more portable when users want to download a notebook as a .R script instead of the .ipynb format.