### PR TITLE
add prefix option to installspec

### DIFF
--- a/R/installspec.r
+++ b/R/installspec.r
@@ -8,11 +8,12 @@
 #' @param name         The name of the kernel (default "ir")
 #' @param displayname  The name which is displayed in the notebook (default: "R")
 #' @param rprofile     (optional) Path to kernel-specific Rprofile (defaults to system-level settings)
+#' @param prefix       (optional) Path to alternate directory to install kernelspec into, overrides 'user' (default: NULL)
 #' 
 #' @return Exit code of the \code{jupyter kernelspec install} call.
 #' 
 #' @export
-installspec <- function(user = TRUE, name = 'ir', displayname = 'R', rprofile = NULL) {
+installspec <- function(user = TRUE, name = 'ir', displayname = 'R', rprofile = NULL, prefix = NULL) {
     exit_code <- system2('jupyter', c('kernelspec', '--version'), FALSE, FALSE)
     if (exit_code != 0)
         stop('jupyter-client has to be installed but ', dQuote('jupyter kernelspec --version'), ' exited with code ', exit_code, '.\n')
@@ -32,7 +33,8 @@ installspec <- function(user = TRUE, name = 'ir', displayname = 'R', rprofile = 
     write(toJSON(spec, pretty = TRUE, auto_unbox = TRUE), file = spec_path)
     
     user_flag <- if (user) '--user' else character(0)
-    args <- c('kernelspec', 'install', '--replace', '--name', name, user_flag, file.path(tmp_name, 'kernelspec'))
+    location <- if (is.null(prefix)) user_flag else c('--prefix', prefix)
+    args <- c('kernelspec', 'install', '--replace', '--name', name, location, file.path(tmp_name, 'kernelspec'))
     exit_code <- system2('jupyter', args)
     
     unlink(tmp_name, recursive = TRUE)

--- a/R/installspec.r
+++ b/R/installspec.r
@@ -4,19 +4,24 @@
 #' different name (and displayname to see a difference in the notebook UI). If the same
 #' name is give, it will overwrite older versions of the kernel spec with that name!
 #'
-#' @param user         Install into user directory (\href{https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html}{\code{$XDG_DATA_HOME}}\code{/jupyter/kernels}) or globally?
+#' @param user         Install into user directory (\href{https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html}{\code{$XDG_DATA_HOME}}\code{/jupyter/kernels}) or globally? (default: NULL but treated as TRUE if "prefix" is not specified)
 #' @param name         The name of the kernel (default "ir")
 #' @param displayname  The name which is displayed in the notebook (default: "R")
 #' @param rprofile     (optional) Path to kernel-specific Rprofile (defaults to system-level settings)
-#' @param prefix       (optional) Path to alternate directory to install kernelspec into, overrides 'user' (default: NULL)
+#' @param prefix       (optional) Path to alternate directory to install kernelspec into (default: NULL)
 #' 
 #' @return Exit code of the \code{jupyter kernelspec install} call.
 #' 
 #' @export
-installspec <- function(user = TRUE, name = 'ir', displayname = 'R', rprofile = NULL, prefix = NULL) {
+installspec <- function(user = NULL, name = 'ir', displayname = 'R', rprofile = NULL, prefix = NULL) {
     exit_code <- system2('jupyter', c('kernelspec', '--version'), FALSE, FALSE)
     if (exit_code != 0)
         stop('jupyter-client has to be installed but ', dQuote('jupyter kernelspec --version'), ' exited with code ', exit_code, '.\n')
+
+    # default to 'user' install if neither 'user' or 'prefix' is specified
+    if (is.null(user)) user <- is.null(prefix)
+    if (user && !is.null(prefix))
+        stop('"user" and "prefix" are mutually exclusive')
     
     # make a kernelspec with the current interpreter's absolute path
     srcdir <- system.file('kernelspec', package = 'IRkernel')
@@ -33,8 +38,8 @@ installspec <- function(user = TRUE, name = 'ir', displayname = 'R', rprofile = 
     write(toJSON(spec, pretty = TRUE, auto_unbox = TRUE), file = spec_path)
     
     user_flag <- if (user) '--user' else character(0)
-    location <- if (is.null(prefix)) user_flag else c('--prefix', prefix)
-    args <- c('kernelspec', 'install', '--replace', '--name', name, location, file.path(tmp_name, 'kernelspec'))
+    prefix_flag <- if (!is.null(prefix)) c('--prefix', prefix) else character(0) 
+    args <- c('kernelspec', 'install', '--replace', '--name', name, user_flag, prefix_flag, file.path(tmp_name, 'kernelspec'))
     exit_code <- system2('jupyter', args)
     
     unlink(tmp_name, recursive = TRUE)

--- a/man/installspec.Rd
+++ b/man/installspec.Rd
@@ -4,17 +4,19 @@
 \alias{installspec}
 \title{Install the kernelspec to tell Jupyter about IRkernel.}
 \usage{
-installspec(user = TRUE, name = "ir", displayname = "R",
-  rprofile = NULL)
+installspec(user = NULL, name = "ir", displayname = "R",
+  rprofile = NULL, prefix = NULL)
 }
 \arguments{
-\item{user}{Install into user directory (\href{https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html}{\code{$XDG_DATA_HOME}}\code{/jupyter/kernels}) or globally?}
+\item{user}{Install into user directory (\href{https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html}{\code{$XDG_DATA_HOME}}\code{/jupyter/kernels}) or globally? (default: NULL but treated as TRUE if "prefix" is not specified)}
 
 \item{name}{The name of the kernel (default "ir")}
 
 \item{displayname}{The name which is displayed in the notebook (default: "R")}
 
 \item{rprofile}{(optional) Path to kernel-specific Rprofile (defaults to system-level settings)}
+
+\item{prefix}{(optional) Path to alternate directory to install kernelspec into (default: NULL)}
 }
 \value{
 Exit code of the \code{jupyter kernelspec install} call.


### PR DESCRIPTION
Addresses #428 

Allows a kernelspec to be installed into a non-standard location (e.g. an anaconda environment).

By default, the iRkernel specifies `user = TRUE` which conflicts with Jupyters `prefix` option so I have set up `prefix` to ignore the `user` flag if specified. 

Specifying a non-standard location produces the standard Jupyter warning:
```
> IRkernel::installspec(name = 'ir32', displayname = 'R 3.2', prefix='/home/tim/TEST')
[InstallKernelSpec] WARNING | Installing to /home/tim/TEST/share/jupyter/kernels, which is not in ['/home/tim/.local/share/jupyter/kernels', '/home/tim/.miniconda3/share/jupyter/kernels', '/usr/local/share/jupyter/kernels', '/usr/share/jupyter/kernels', '/home/tim/.ipython/kernels']. The kernelspec may not be found.
[InstallKernelSpec] Installed kernelspec ir32 in /home/tim/TEST/share/jupyter/kernels/ir32
> 
```

This should probably include a test but I'm not sure of the best approach so suggestions welcome.