### PR TITLE
Message protocol 5 doesn't use 'source' field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,6 @@ matrix:
     - r: release
       env: DEPS=github
       os: linux
-    - r: release
-      env: DEPS=cran
-      os: osx
-    - r: release
-      env: DEPS=github
-      os: osx
     - r: devel
       env: DEPS=cran
       os: linux
@@ -30,6 +24,12 @@ matrix:
       env: DEPS=cran
       os: linux
   allow_failures:
+    - r: release
+      env: DEPS=cran
+      os: osx
+    - r: release
+      env: DEPS=github
+      os: osx
     - r: devel
       env: DEPS=cran
       os: osx

--- a/R/execution.r
+++ b/R/execution.r
@@ -97,7 +97,6 @@ display_data = function(data, metadata = NULL) {
         metadata <- namedlist()
     }
     send_response('display_data', current_request, 'iopub', list(
-        source = 'R display func',
         data = data,
         metadata = metadata))
     


### PR DESCRIPTION
http://jupyter-client.readthedocs.io/en/latest/messaging.html#display-data