### PR TITLE
Internally use original `quit` function instead of the one provided for users

### DIFF
--- a/R/environment_shadow.r
+++ b/R/environment_shadow.r
@@ -36,6 +36,7 @@ backup_env$utils_flush_console <- function(...) {}
 init_backup_env <- function() {
     backup_env$base_flush_connection <- base::flush.connection
     backup_env$utils_flush_console <- utils::flush.console
+    backup_env$base_quit <- base::quit
 }
 
 # Adds functions which do not need any access to the executer into the users searchpath

--- a/R/kernel.r
+++ b/R/kernel.r
@@ -363,7 +363,8 @@ handle_control = function() {
 shutdown = function(request) {
     send_response('shutdown_reply', request, 'control', list(
         restart = request$content$restart))
-    quit('no')
+    # Always call the base quit() during shutdown since execution shadows it.
+    backup_env$base_quit('no')  # bound during startup in .onLoad
 },
 
 initialize = function(connection_file) {
@@ -407,6 +408,7 @@ initialize = function(connection_file) {
 
 run = function() {
     options(jupyter.in_kernel = TRUE)
+
     while (TRUE) {
         log_debug('main loop: beginning')
         r <- tryCatch(


### PR DESCRIPTION
The replacement of the base `quit()` function with `execution.r/quit()`
prevents message-based shutdown requests from completing, triggering the
juptyer framework's kill sequence.  If the shading is not performed,
kernels can be properly shutdown via the initial request and prevent
the additional overhead and potential unreliability of kill sequence
(signals, REST apis, etc.).

Since my knowledge of R is extremely limited, there may be far better
ways to handle this, so please feel free to comment to that affect.
Also, it's not clear to me what functionality I'm preventing by making
this change.

To enable the skipping of the replacement, a new option has been added:
`jupyter.replace_quit` (env: `JUPYTER_REPLACE_QUIT`) default value is
`TRUE` so the current functionality is retained.  When set to FALSE,
the replacement of the base `quit()` method is not performed.

I'm not thrilled by the name either, and if I better understood why the
`quit()` method was necessary in the first place, I'd be happy to come
up with a different name.  I kinda wonder if using `jupyter.in_kernel`
for this would be better since it seems like we'd always want successful
message-based shutdown requests.

Please refer to Issue #569 for how to test.  The key thing is that,
at a minimum, Notebook DEBUG logging be enabled so one can determine
if the kill sequence is being invoked.  Another way is if the kernel's
termination takes on the order of 5 seconds vs sub-second.

Fixes #569