### PR TITLE
Fix string completion test

### DIFF
--- a/tests/testthat/test_ir.py
+++ b/tests/testthat/test_ir.py
@@ -59,7 +59,7 @@ class IRkernelTests(jkt.KernelTests):
         {'text': 'repr:::repr_png.def',    'matches': {'repr:::repr_png.default'}},
         {'text': 'repr::format2repr$mark', 'matches': {'repr::format2repr$markdown'}},
         {'text': 'load("test_i',           'matches': {'test_ir.py'}},
-        {'text': 'load("../test',          'matches': {'../testthat.R', '../testthat/'}},
+        {'text': 'load("../test',          'matches': {'../testthat.Rout', '../testthat.R', '../testthat/'}},
     ]
 
     complete_code_samples = ['1', 'print("hello, world")', 'f <- function(x) {\n  x*2\n}']


### PR DESCRIPTION
It seems that "testthat.Rout" file is created when testing.