### PR TITLE
Add sys_prefix option to mirror --sys-prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ IRkernel::installspec(name = 'ir33', displayname = 'R 3.3')
 IRkernel::installspec(name = 'ir32', displayname = 'R 3.2')
 ```
 
+By default, it installs the kernel per-user.  To install system-wide,
+use `user = FALSE`.  To install in the `sys.prefix` of the currently
+detected `jupyter` command line utility, use `sys_prefix = TRUE`.
+
 Now both R versions are available as an R kernel in the notebook.
 
 ### If you encounter problems during installation
@@ -76,3 +80,14 @@ make docker_dev_image #builds dev image and installs IRkernel dependencies from 
 make docker_dev #mounts source, installs, and runs Jupyter notebook; docker_dev_image is a prerequisite
 make docker_test #builds the package from source then runs the tests via R CMD check; docker_dev_image is a prerequisite
 ```
+
+## How does it know where to install?
+
+The IRKernel does not have any Python dependencies whatsoever, and
+does not know anything about any other Jupyter/Python installations
+you may have.  It only requires the `jupyter` command to be available
+on `$PATH`.  To install the kernel, it prepares a kernelspec directory
+(containing `kernel.json` and so on), and passes it to the command
+line `jupyter kernelspec install [options] prepared_kernel_dir/`,
+where options such as `--name`, `--user`, `--prefix`, and
+`--sys-prefix` are given based on the options.

--- a/man/installspec.Rd
+++ b/man/installspec.Rd
@@ -9,7 +9,8 @@ installspec(
   name = "ir",
   displayname = "R",
   rprofile = NULL,
-  prefix = NULL
+  prefix = NULL,
+  sys_prefix = NULL
 )
 }
 \arguments{
@@ -22,6 +23,8 @@ installspec(
 \item{rprofile}{(optional) Path to kernel-specific Rprofile (defaults to system-level settings)}
 
 \item{prefix}{(optional) Path to alternate directory to install kernelspec into (default: NULL)}
+
+\item{sys_prefix}{(optional) Install kernelspec using the "--sys-prefix" option of the currently detected jupyter (default: NULL)}
 }
 \value{
 Exit code of the \code{jupyter kernelspec install} call.


### PR DESCRIPTION
In my work deploying jupyter to people, I've been annoyed that there
is no `--sys-prefix` equivalent for IRkernel.  Well, maybe I should do
something about it...

- Add installspec(sys_prefix=TRUE) option to install using the
  equivalent of --sys-prefix.  Support added in jupyter-client 4.3
  (2016).  This is passed directly to the underlying `jupyter
  kernelspec install` command.
- No tests yet, but user=TRUE doesn't seem to be either...

I'm not an R expert, and I haven't even tested this code myself.  But
I figure that making prototype quickly is better than abstract
discussion, so here it is.  This would have saved me plenty of time
over the years.

Whether or not this goes through, I will try to improve the
installation docs some - it would have also saved me time, as a
cluster manager who needs to know some more details about what's going
on.