### PR TITLE
Add `date` to reply messages

### DIFF
--- a/R/execution.r
+++ b/R/execution.r
@@ -326,7 +326,7 @@ execute = function(request) {
         else if (!is.null(err$ename)) 'error'
         else 'ok'
 
-    log_debug('Code execution reasult: %s', status)
+    log_debug('Code execution result: %s', status)
     
     reply_content <- c(
         list(

--- a/R/kernel.r
+++ b/R/kernel.r
@@ -1,4 +1,6 @@
 #' @include execution.r help.r comm_manager.r logging.r utils.r
+PROTOCOL_VER = '5.3'
+
 Kernel <- setRefClass(
     'Kernel',
     fields = list(
@@ -77,10 +79,12 @@ new_reply = function(msg_type, parent_msg) {
     
     header <- list(
         msg_id   = UUIDgenerate(),
-        username = parent_msg$header$username,
         session  = parent_msg$header$session,
+        username = parent_msg$header$username,
+        # ISO 8601
+        date = strftime(as.POSIXlt(Sys.time(), 'UTC'), '%Y-%m-%dT%H:%M:%S%z'),
         msg_type = msg_type,
-        version  = '5.0')
+        version  = PROTOCOL_VER)
     
     list(
         header        = header,
@@ -309,7 +313,7 @@ history = function(request) {
 kernel_info = function(request) {
     rversion <- paste0(version$major, '.', version$minor)
     send_response('kernel_info_reply', request, 'shell', list(
-        protocol_version       = '5.0',
+        protocol_version       = PROTOCOL_VER,
         implementation         = 'IRkernel',
         implementation_version = as.character(packageVersion('IRkernel')),
         language_info = list(

--- a/R/kernel.r
+++ b/R/kernel.r
@@ -104,7 +104,7 @@ send_response = function(msg_type, parent_msg, socket_name, content) {
     msg$content <- content
     socket <- sockets[[socket_name]]
     zmq.send.multipart(socket, msg_to_wire(msg), serialize = FALSE)
-    log_debug('Sending msg %s', msg$header$msg_type)
+    log_debug('Sending msg %s.%s', socket_name, msg$header$msg_type)
 },
 
 handle_shell = function() {

--- a/R/kernel.r
+++ b/R/kernel.r
@@ -81,8 +81,8 @@ new_reply = function(msg_type, parent_msg) {
         msg_id   = UUIDgenerate(),
         session  = parent_msg$header$session,
         username = parent_msg$header$username,
-        # ISO 8601
-        date = strftime(as.POSIXlt(Sys.time(), 'UTC'), '%Y-%m-%dT%H:%M:%S%z'),
+        # ISO 8601, 6 is the maximum number decimal digits supported by R
+        date = strftime(as.POSIXlt(Sys.time(), 'UTC'), '%Y-%m-%dT%H:%M:%OS6Z'),
         msg_type = msg_type,
         version  = PROTOCOL_VER)
     


### PR DESCRIPTION
Also the kernel now identifies as 5.3. I hope I didn’t miss any changes from 5.0 to 5.3.