### PR TITLE
adjust comps regex not to wrap names with leading . in backticks

### DIFF
--- a/R/completion.r
+++ b/R/completion.r
@@ -49,7 +49,7 @@ fixup_comps <- function(comps) {
     
     # wrap non-identifiers with ``
     # https://cran.r-project.org/doc/manuals/r-release/R-lang.html#Identifiers
-    comps <- gsub('^([_.].*?|.*?[^\\w\\d._].*?|.*?[.]\\d)$', '`\\1`', comps, perl = TRUE)
+    comps <- gsub('^(_.*?|[.]{2,}.*?|.*?[^\\w\\d._].*?|.*?[.]\\d)$', '`\\1`', comps, perl = TRUE)
     
     # good coding style for completions
     trailing <- gsub('=', ' = ', trailing)

--- a/tests/testthat/test_ir.py
+++ b/tests/testthat/test_ir.py
@@ -60,6 +60,7 @@ class IRkernelTests(jkt.KernelTests):
         {'text': 'repr::format2repr$mark', 'matches': {'repr::format2repr$markdown'}},
         {'text': 'load("test_i',           'matches': {'test_ir.py'}},
         {'text': 'load("./test_',          'matches': {'./test_utils.r', './test_kernel.r', './test_ir.py'}},
+        {'text': '.Last.v',                'matches': {'.Last.value'}},
     ]
 
     complete_code_samples = ['1', 'print("hello, world")', 'f <- function(x) {\n  x*2\n}']


### PR DESCRIPTION
Closes #681

This passes the existing tests mentioned in the issue, however PTAL as I'm not sure how comprehensive that list is.