### PR TITLE
Get parent header from current request

### DIFF
--- a/R/main.r
+++ b/R/main.r
@@ -12,5 +12,6 @@ main <- function(connection_file = '') {
     }
     log_debug('Starting the R kernel...')
     kernel <- Kernel$new(connection_file = connection_file)
+    runtime_env$kernel <- kernel
     kernel$run()
 }


### PR DESCRIPTION
- Use `current_request` as`parent_msg` is `parent_msg` is `NULL`
- Support `metadata` in `send_response`