### PR TITLE
improve tab-completion of non-syntactic names

### DIFF
--- a/R/completion.r
+++ b/R/completion.r
@@ -58,8 +58,9 @@ fixup_comps <- function(comps) {
     last_match <- vapply(lead_matches, tail, n = 1L, integer(1L))
     has_match <- last_match > 0L
     leading <- rep("", length(comps))
-    leading[has_match] <- substr(comps[has_match], 1L, last_match - 1L)
-    comps[has_match] <- substr(comps[has_match], last_match, nchar(comps[has_match]))
+    comps_with_leading <- comps[has_match]
+    leading[has_match] <- substr(comps_with_leading, 1L, last_match - 1L)
+    comps[has_match] <- substr(comps_with_leading, last_match, nchar(comps_with_leading))
     
     # wrap non-identifiers with ``; h/t the related r-devel thread:
     #   https://stat.ethz.ch/pipermail/r-devel/2023-March/082388.html

--- a/R/completion.r
+++ b/R/completion.r
@@ -51,6 +51,9 @@ fixup_comps <- function(comps) {
     comps <- gsub(sprintf('(%s)$', re_trail), '', comps, perl = TRUE)
 
     # split off everything before the last special operator (a la utils:::specialOpLocs)
+    # NB: use look-behind so that we can use the output directly without worrying about
+    #   match.length. Separate look-behind conditions because each one must have a
+    #   fixed length.
     lead_matches <- gregexpr("(?<=[$])|(?<=@)|(?<=[^:]::)|(?<=:::)", comps, perl = TRUE)
     last_match <- vapply(lead_matches, utils::tail, n = 1L, integer(1L))
     has_match <- last_match > 0L
@@ -69,7 +72,7 @@ fixup_comps <- function(comps) {
     )
 
     # good coding style for completions
-    trailing <- gsub('=', ' = ', trailing)
+    trailing <- gsub('=', ' = ', trailing, fixed = TRUE)
     comps <- paste0(leading, comps, trailing)
     comps[comps == "... = "] <- "..."
     comps

--- a/R/completion.r
+++ b/R/completion.r
@@ -54,7 +54,7 @@ fixup_comps <- function(comps) {
     # NB: use look-behind so that we can use the output directly without worrying about
     #   match.length. Separate look-behind conditions because each one must have a
     #   fixed length.
-    lead_matches <- gregexpr("(?<=[$])|(?<=@)|(?<=[^:]::)|(?<=:::)", comps, perl = TRUE)
+    lead_matches <- gregexpr("(?<=[$@])|(?<=[^:]::)|(?<=:::)", comps, perl = TRUE)
     last_match <- vapply(lead_matches, tail, n = 1L, integer(1L))
     has_match <- last_match > 0L
     leading <- rep("", length(comps))

--- a/R/completion.r
+++ b/R/completion.r
@@ -57,8 +57,7 @@ fixup_comps <- function(comps) {
     lead_matches <- gregexpr("(?<=[$])|(?<=@)|(?<=[^:]::)|(?<=:::)", comps, perl = TRUE)
     last_match <- vapply(lead_matches, utils::tail, n = 1L, integer(1L))
     has_match <- last_match > 0L
-    leading <- character(length(comps))
-    leading[!has_match] <- ""
+    leading <- rep("", length(comps))
     leading[has_match] <- substr(comps[has_match], 1L, last_match - 1L)
     comps[has_match] <- substr(comps[has_match], last_match, nchar(comps[has_match]))
     
@@ -67,6 +66,7 @@ fixup_comps <- function(comps) {
     non_empty <- nzchar(comps)
     comps[non_empty] <- vapply(
         comps[non_empty],
+        # TODO(R>=4.0.0) use deparse1() for brevity
         function(nm) paste(deparse(as.name(nm), backtick = TRUE), collapse = " "),
         character(1L)
     )

--- a/R/completion.r
+++ b/R/completion.r
@@ -55,7 +55,7 @@ fixup_comps <- function(comps) {
     #   match.length. Separate look-behind conditions because each one must have a
     #   fixed length.
     lead_matches <- gregexpr("(?<=[$])|(?<=@)|(?<=[^:]::)|(?<=:::)", comps, perl = TRUE)
-    last_match <- vapply(lead_matches, utils::tail, n = 1L, integer(1L))
+    last_match <- vapply(lead_matches, tail, n = 1L, integer(1L))
     has_match <- last_match > 0L
     leading <- rep("", length(comps))
     leading[has_match] <- substr(comps[has_match], 1L, last_match - 1L)

--- a/R/completion.r
+++ b/R/completion.r
@@ -71,5 +71,6 @@ fixup_comps <- function(comps) {
     # good coding style for completions
     trailing <- gsub('=', ' = ', trailing)
     comps <- paste0(leading, comps, trailing)
-    gsub('^`[.][.][.]` = $', '...', comps)
+    comps[comps == "... = "] <- "..."
+    comps
 }

--- a/tests/testthat/test_ir.py
+++ b/tests/testthat/test_ir.py
@@ -319,7 +319,7 @@ class IRkernelTests(jkt.KernelTests):
     def test_non_syntactic_completions(self):
         """Test tab-completion for non-syntactic names which require setup/teardown"""
 
-        for sample in non_syntactic_completion_samples:
+        for sample in self.non_syntactic_completion_samples:
             with self.subTest(text=sample['text']):
                 for var_name, var_value in sample['vars'].items():
                     self._execute_code(f'{var_name} <- {var_value}', tests=False)

--- a/tests/testthat/test_ir.py
+++ b/tests/testthat/test_ir.py
@@ -307,13 +307,27 @@ class IRkernelTests(jkt.KernelTests):
                     self._execute_code(f'rm("{var_name}")', tests=False)
 
     non_syntactic_completion_samples = [
-        dict(text='xx$host[[1]]$h', matches=['xx$host[[1]]$h1', 'xx$host[[1]]$h2'], vars=dict(xx='list(host = list(list(h1 = 1, h2 = 2), list(h3 = 3, h4 = 4)))')),
-        dict(text='odd_named_list$a', matches=['odd_named_list$a'], vars=dict(odd_named_list=r'list(a = 1, b = 2, `b c` = 3, `\`\\\`` = 4, 5)')),
-        dict(text='odd_named_list$b', matches=['odd_named_list$b', 'odd_named_list$`b c`'], vars=dict(odd_named_list=r'list(a = 1, b = 2, `b c` = 3, `\`\\\`` = 4, 5)')),
-        dict(text='odd_named_list$', matches=['odd_named_list$a', 'odd_named_list$b', 'odd_named_list$`b c`', r'odd_named_list$`\`\\\``', 'odd_named_list$'], vars=dict(odd_named_list=r'list(a = 1, b = 2, `b c` = 3, `\`\\\`` = 4, 5)')),
-        dict(text='arith_named_env$a', matches=['arith_named_env$`abc+def`', 'arith_named_env$`abc-def`'], vars=dict(arith_named_env='list2env(list(`abc+def` = 1, `def-abc` = 2, `abc-def` = 3, defabc = 4))')),
-        dict(text='arith_named_env$def', matches=['arith_named_env$`def-abc`', 'arith_named_env$defabc'], vars=dict(arith_named_env='list2env(list(`abc+def` = 1, `def-abc` = 2, `abc-def` = 3, defabc = 4))')),
-        dict(text='arith_named_env$', matches=['arith_named_env$`abc+def`', 'arith_named_env$`def-abc`', 'arith_named_env$`abc-def`', 'arith_named_env$defabc'], vars=dict(arith_named_env='list2env(list(`abc+def` = 1, `def-abc` = 2, `abc-def` = 3, defabc = 4))')),
+        dict(text='xx$host[[1]]$h',
+             matches=['xx$host[[1]]$h1', 'xx$host[[1]]$h2'],
+             vars=dict(xx='list(host = list(list(h1 = 1, h2 = 2), list(h3 = 3, h4 = 4)))')),
+        dict(text='odd_named_list$a',
+             matches=['odd_named_list$a'],
+             vars=dict(odd_named_list=r'list(a = 1, b = 2, `b c` = 3, `\`\\\`` = 4, 5)')),
+        dict(text='odd_named_list$b',
+             matches=['odd_named_list$b', 'odd_named_list$`b c`'],
+             vars=dict(odd_named_list=r'list(a = 1, b = 2, `b c` = 3, `\`\\\`` = 4, 5)')),
+        dict(text='odd_named_list$',
+             matches=['odd_named_list$a', 'odd_named_list$b', 'odd_named_list$`b c`', r'odd_named_list$`\`\\\``', 'odd_named_list$'],
+             vars=dict(odd_named_list=r'list(a = 1, b = 2, `b c` = 3, `\`\\\`` = 4, 5)')),
+        dict(text='arith_named_env$a',
+             matches=['arith_named_env$`abc+def`', 'arith_named_env$`abc-def`'],
+             vars=dict(arith_named_env='list2env(list(`abc+def` = 1, `def-abc` = 2, `abc-def` = 3, defabc = 4))')),
+        dict(text='arith_named_env$def',
+             matches=['arith_named_env$`def-abc`', 'arith_named_env$defabc'],
+             vars=dict(arith_named_env='list2env(list(`abc+def` = 1, `def-abc` = 2, `abc-def` = 3, defabc = 4))')),
+        dict(text='arith_named_env$',
+             matches=['arith_named_env$`abc+def`', 'arith_named_env$`def-abc`', 'arith_named_env$`abc-def`', 'arith_named_env$defabc'],
+             vars=dict(arith_named_env='list2env(list(`abc+def` = 1, `def-abc` = 2, `abc-def` = 3, defabc = 4))')),
     ]
 
     def test_non_syntactic_completions(self):

--- a/tests/testthat/test_ir.py
+++ b/tests/testthat/test_ir.py
@@ -310,7 +310,7 @@ class IRkernelTests(jkt.KernelTests):
         dict(text='xx$host[[1]]$h', matches=['xx$host[[1]]$h1', 'xx$host[[1]]$h2'], vars=dict(xx='list(host = list(list(h1 = 1, h2 = 2), list(h3 = 3, h4 = 4)))')),
         dict(text='odd_named_list$a', matches=['odd_named_list$a'], vars=dict(odd_named_list=r'list(a = 1, b = 2, `b c` = 3, `\`\\\`` = 4, 5)')),
         dict(text='odd_named_list$b', matches=['odd_named_list$b', 'odd_named_list$`b c`'], vars=dict(odd_named_list='list(a = 1, b = 2, `b c` = 3, 4, 5)')),
-        dict(text='odd_named_list$', matches=['odd_named_list$a', 'odd_named_list$`b c`', r'odd_named_list$`\`\\\``', 'odd_named_list$'], vars=dict(odd_named_list='list(a = 1, b = 2, `b c` = 3, 4, 5)')),
+        dict(text='odd_named_list$', matches=['odd_named_list$a', 'odd_named_list$b', 'odd_named_list$`b c`', r'odd_named_list$`\`\\\``', 'odd_named_list$'], vars=dict(odd_named_list='list(a = 1, b = 2, `b c` = 3, `\`\\\`` = 4, 5)')),
         dict(text='arith_named_env$a', matches=['arith_named_env$`abc+def`', 'arith_named_env$`abc-def`'], vars=dict(arith_named_env='list2env(list(`abc+def` = 1, `def-abc` = 2, `abc-def` = 3, defabc = 4))')),
         dict(text='arith_named_env$def', matches=['arith_named_env$`def-abc`', 'arith_named_env$defabc'], vars=dict(arith_named_env='list2env(list(`abc+def` = 1, `def-abc` = 2, `abc-def` = 3, defabc = 4))')),
         dict(text='arith_named_env$', matches=['arith_named_env$`abc+def`', 'arith_named_env$`def-abc`', 'arith_named_env$`abc-def`', 'arith_named_env$defabc'], vars=dict(arith_named_env='list2env(list(`abc+def` = 1, `def-abc` = 2, `abc-def` = 3, defabc = 4))')),

--- a/tests/testthat/test_ir.py
+++ b/tests/testthat/test_ir.py
@@ -308,7 +308,7 @@ class IRkernelTests(jkt.KernelTests):
 
     non_syntactic_completion_samples = [
         dict(text='xx$host[[1]]$h', matches=['xx$host[[1]]$h1', 'xx$host[[1]]$h2'], vars=dict(xx='list(host = list(list(h1 = 1, h2 = 2), list(h3 = 3, h4 = 4)))')),
-        dict(text='odd_named_list$a', matches=['odd_named_list$a'], vars=dict(odd_named_list='list(a = 1, b = 2, `b c` = 3, 4, 5)')),
+        dict(text='odd_named_list$a', matches=['odd_named_list$a'], vars=dict(odd_named_list=r'list(a = 1, b = 2, `b c` = 3, `\`\\\`` = 4, 5)')),
         dict(text='odd_named_list$b', matches=['odd_named_list$b', 'odd_named_list$`b c`'], vars=dict(odd_named_list='list(a = 1, b = 2, `b c` = 3, 4, 5)')),
         dict(text='odd_named_list$', matches=['odd_named_list$a', 'odd_named_list$`b c`', r'odd_named_list$`\`\\\``', 'odd_named_list$'], vars=dict(odd_named_list='list(a = 1, b = 2, `b c` = 3, 4, 5)')),
         dict(text='arith_named_env$a', matches=['arith_named_env$`abc+def`', 'arith_named_env$`abc-def`'], vars=dict(arith_named_env='list2env(list(`abc+def` = 1, `def-abc` = 2, `abc-def` = 3, defabc = 4))')),

--- a/tests/testthat/test_ir.py
+++ b/tests/testthat/test_ir.py
@@ -309,8 +309,8 @@ class IRkernelTests(jkt.KernelTests):
     non_syntactic_completion_samples = [
         dict(text='xx$host[[1]]$h', matches=['xx$host[[1]]$h1', 'xx$host[[1]]$h2'], vars=dict(xx='list(host = list(list(h1 = 1, h2 = 2), list(h3 = 3, h4 = 4)))')),
         dict(text='odd_named_list$a', matches=['odd_named_list$a'], vars=dict(odd_named_list=r'list(a = 1, b = 2, `b c` = 3, `\`\\\`` = 4, 5)')),
-        dict(text='odd_named_list$b', matches=['odd_named_list$b', 'odd_named_list$`b c`'], vars=dict(odd_named_list='list(a = 1, b = 2, `b c` = 3, `\`\\\`` = 4, 5)')),
-        dict(text='odd_named_list$', matches=['odd_named_list$a', 'odd_named_list$b', 'odd_named_list$`b c`', r'odd_named_list$`\`\\\``', 'odd_named_list$'], vars=dict(odd_named_list='list(a = 1, b = 2, `b c` = 3, `\`\\\`` = 4, 5)')),
+        dict(text='odd_named_list$b', matches=['odd_named_list$b', 'odd_named_list$`b c`'], vars=dict(odd_named_list=r'list(a = 1, b = 2, `b c` = 3, `\`\\\`` = 4, 5)')),
+        dict(text='odd_named_list$', matches=['odd_named_list$a', 'odd_named_list$b', 'odd_named_list$`b c`', r'odd_named_list$`\`\\\``', 'odd_named_list$'], vars=dict(odd_named_list=r'list(a = 1, b = 2, `b c` = 3, `\`\\\`` = 4, 5)')),
         dict(text='arith_named_env$a', matches=['arith_named_env$`abc+def`', 'arith_named_env$`abc-def`'], vars=dict(arith_named_env='list2env(list(`abc+def` = 1, `def-abc` = 2, `abc-def` = 3, defabc = 4))')),
         dict(text='arith_named_env$def', matches=['arith_named_env$`def-abc`', 'arith_named_env$defabc'], vars=dict(arith_named_env='list2env(list(`abc+def` = 1, `def-abc` = 2, `abc-def` = 3, defabc = 4))')),
         dict(text='arith_named_env$', matches=['arith_named_env$`abc+def`', 'arith_named_env$`def-abc`', 'arith_named_env$`abc-def`', 'arith_named_env$defabc'], vars=dict(arith_named_env='list2env(list(`abc+def` = 1, `def-abc` = 2, `abc-def` = 3, defabc = 4))')),

--- a/tests/testthat/test_ir.py
+++ b/tests/testthat/test_ir.py
@@ -309,7 +309,7 @@ class IRkernelTests(jkt.KernelTests):
     non_syntactic_completion_samples = [
         dict(text='xx$host[[1]]$h', matches=['xx$host[[1]]$h1', 'xx$host[[1]]$h2'], vars=dict(xx='list(host = list(list(h1 = 1, h2 = 2), list(h3 = 3, h4 = 4)))')),
         dict(text='odd_named_list$a', matches=['odd_named_list$a'], vars=dict(odd_named_list=r'list(a = 1, b = 2, `b c` = 3, `\`\\\`` = 4, 5)')),
-        dict(text='odd_named_list$b', matches=['odd_named_list$b', 'odd_named_list$`b c`'], vars=dict(odd_named_list='list(a = 1, b = 2, `b c` = 3, 4, 5)')),
+        dict(text='odd_named_list$b', matches=['odd_named_list$b', 'odd_named_list$`b c`'], vars=dict(odd_named_list='list(a = 1, b = 2, `b c` = 3, `\`\\\`` = 4, 5)')),
         dict(text='odd_named_list$', matches=['odd_named_list$a', 'odd_named_list$b', 'odd_named_list$`b c`', r'odd_named_list$`\`\\\``', 'odd_named_list$'], vars=dict(odd_named_list='list(a = 1, b = 2, `b c` = 3, `\`\\\`` = 4, 5)')),
         dict(text='arith_named_env$a', matches=['arith_named_env$`abc+def`', 'arith_named_env$`abc-def`'], vars=dict(arith_named_env='list2env(list(`abc+def` = 1, `def-abc` = 2, `abc-def` = 3, defabc = 4))')),
         dict(text='arith_named_env$def', matches=['arith_named_env$`def-abc`', 'arith_named_env$defabc'], vars=dict(arith_named_env='list2env(list(`abc+def` = 1, `def-abc` = 2, `abc-def` = 3, defabc = 4))')),


### PR DESCRIPTION
Closes #733.

Incorporates feedback/suggestions from the upstream discussion for R-core:

 - https://stat.ethz.ch/pipermail/r-devel/2023-March/082388.html
 - https://bugs.r-project.org/show_bug.cgi?id=18479
 - https://github.com/r-devel/r-svn/pull/112

@flying-sheep please guide me how to add test cases. I think, as opposed to the other test cases I see thus far in tests/testthat/test_ir.py, we need to define some R variables first (like `xx` in the #733 issue body or the examples added to the r-svn PR), and I don't see an example of how to do that in the suite as of now.