### PR TITLE
Avoid library() in test files

### DIFF
--- a/tests/testthat/test_utils.r
+++ b/tests/testthat/test_utils.r
@@ -1,7 +1,5 @@
 context('utils')
 
-library(evaluate)
-
 test_that('skip_repeated works', {
     stack <- c('foo()', 'f()', 'f()', 'f()', 'f()', 'bar()')
     expect_equal(skip_repeated(stack), c('foo()', 'f()', ellip_h, 'f()', 'bar()'))
@@ -13,10 +11,10 @@ test_that('skip_repeated does not skip three or less consecutive items', {
 })
 
 test_that('skip_repeated works on tracebacks', {
-    err <- try_capture_stack(quote({
+    err <- evaluate::try_capture_stack(quote({
         f <- function(x) stop(x)
         f(1)
     }), new.env())
     skipped_stack <- skip_repeated(err$calls)
-    expect_is(skipped_stack[[1]], 'call')
+    expect_type(skipped_stack[[1]], 'language')
 })


### PR DESCRIPTION
This makes tests less hermetic by creating permanent side effects that survive the test file.

Also remove deprecated `expect_is()` in anticipation of upgrading to {testthat} 3rd edition.