### PR TITLE
Add env parameter to installspec

### DIFF
--- a/R/installspec.r
+++ b/R/installspec.r
@@ -38,8 +38,8 @@ installspec <- function(
     spec$argv[[1]] <- file.path(R.home('bin'), 'R')
     spec$display_name <- displayname
 
-    spec$env <- if (!is.null(env)) env else list()
-    if (!is.list(spec$env))
+    spec$env <- if (!is.null(env)) env else namedlist()
+    if (!is.list(spec$env) || is.null(names(spec$env)))
         stop('`env` needs to be a named list')
     if (!is.null(rprofile))
         spec$env$R_PROFILE_USER <- rprofile

--- a/R/installspec.r
+++ b/R/installspec.r
@@ -11,12 +11,13 @@
 #' @param prefix       (optional) Path to alternate directory to install kernelspec into (default: NULL)
 #' @param sys_prefix   (optional) Install kernelspec using the \code{--sys-prefix} option of the currently detected jupyter (default: NULL)
 #' @param verbose      (optional) If \code{FALSE}, silence output of \code{install}
+#' @param env          (optional) Named list of environment variables to set in the kernel (default: NULL)
 #' 
 #' @return Exit code of the \code{jupyter kernelspec install} call.
 #' 
 #' @export
 installspec <- function(
-    user = NULL, name = 'ir', displayname = 'R', rprofile = NULL, prefix = NULL, sys_prefix = NULL, verbose = getOption('verbose')
+    user = NULL, name = 'ir', displayname = 'R', rprofile = NULL, prefix = NULL, sys_prefix = NULL, verbose = getOption('verbose'), env = NULL
 ) {
     exit_code <- system2('jupyter', c('kernelspec', '--version'), FALSE, FALSE)
     if (exit_code != 0)
@@ -36,9 +37,15 @@ installspec <- function(
     spec <- fromJSON(spec_path)
     spec$argv[[1]] <- file.path(R.home('bin'), 'R')
     spec$display_name <- displayname
-    if (!is.null(rprofile)) {
-        spec$env <- list(R_PROFILE_USER = rprofile)
-    }
+
+    if (!is.null(env) && is.list(env))
+        spec$env <- env
+    else
+        spec$env <- list()
+
+    if (!is.null(rprofile))
+        spec$env$R_PROFILE_USER <- rprofile
+
     write(toJSON(spec, pretty = TRUE, auto_unbox = TRUE), file = spec_path)
     
     user_flag <- if (user) '--user' else character(0)

--- a/R/installspec.r
+++ b/R/installspec.r
@@ -38,11 +38,9 @@ installspec <- function(
     spec$argv[[1]] <- file.path(R.home('bin'), 'R')
     spec$display_name <- displayname
 
-    if (!is.null(env) && is.list(env))
-        spec$env <- env
-    else
-        spec$env <- list()
-
+    spec$env <- if (!is.null(env)) env else list()
+    if (!is.list(spec$env))
+        stop('`env` needs to be a named list')
     if (!is.null(rprofile))
         spec$env$R_PROFILE_USER <- rprofile
 

--- a/man/installspec.Rd
+++ b/man/installspec.Rd
@@ -11,7 +11,8 @@ installspec(
   rprofile = NULL,
   prefix = NULL,
   sys_prefix = NULL,
-  verbose = getOption("verbose")
+  verbose = getOption("verbose"),
+  env = NULL
 )
 }
 \arguments{
@@ -28,6 +29,8 @@ installspec(
 \item{sys_prefix}{(optional) Install kernelspec using the \code{--sys-prefix} option of the currently detected jupyter (default: NULL)}
 
 \item{verbose}{(optional) If \code{FALSE}, silence output of \code{install}}
+
+\item{env}{(optional) Named list of environment variables to set in the kernel (default: NULL)}
 }
 \value{
 Exit code of the \code{jupyter kernelspec install} call.

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
 jupyter
 jupyter-client
-ndjson-testrunner
+ndjson-testrunner>=1.1.3
 jupyter-kernel-test>=0.5.0


### PR DESCRIPTION
Resolves [#620](https://github.com/IRkernel/IRkernel/issues/620)

Allows the user to define environment variables when running installspec()